### PR TITLE
feat: increase precision of proving speed, release-only analytics

### DIFF
--- a/clients/cli/src/config.rs
+++ b/clients/cli/src/config.rs
@@ -1,3 +1,10 @@
+#[cfg(debug_assertions)]
+pub fn analytics_token(_ws_addr_string: &str) -> String {
+    // Use one of the tokens in the release version if debugging analytics
+    return "".into();
+}
+
+#[cfg(not(debug_assertions))]
 pub fn analytics_token(ws_addr_string: &str) -> String {
     if ws_addr_string.starts_with("wss://dev.orchestrator.nexus.xyz:443/") {
         return "504d4d443854f2cd10e2e385aca81aa4".into();

--- a/clients/cli/src/prover.rs
+++ b/clients/cli/src/prover.rs
@@ -225,8 +225,8 @@ async fn main() {
         track(
             "progress".into(),
             format!(
-                "Program trace is {} steps. Proving from {} to {}...",
-                total_steps, start, end
+                "Program trace is {} steps. Proving {} steps starting at {}...",
+                total_steps, steps_to_prove, start
             ),
             &ws_addr_string,
             json!({
@@ -255,11 +255,10 @@ async fn main() {
             };
             let progress_duration = SystemTime::now().duration_since(progress_time).unwrap();
             let cycles_proven = steps_proven * 4;
-            let proof_cycles_hertz = k * 1000 / progress_duration.as_millis();
-            let proof_cycles_per_minute = k * 60 * 1000 / progress_duration.as_millis();
+            let proof_cycles_hertz = k as f64 * 1000.0 / progress_duration.as_millis() as f64;
             track(
                 "progress".into(),
-                format!("Proved step {} at {} Hz.", step, proof_cycles_hertz),
+                format!("Proved step {} at {:.2} proof cycles/sec.", step, proof_cycles_hertz),
                 &ws_addr_string,
                 json!({
                     "completed_fraction": completed_fraction,
@@ -270,7 +269,6 @@ async fn main() {
                     "k": k,
                     "progress_duration_millis": progress_duration.as_millis(),
                     "proof_cycles_hertz": proof_cycles_hertz,
-                    "proof_cycles_per_minute": proof_cycles_per_minute,
                     "prover_id": prover_id,
                 }),
             );
@@ -310,21 +308,19 @@ async fn main() {
                     })),
                 };
                 let duration = SystemTime::now().duration_since(start_time).unwrap();
-                let proof_cycles_hertz = cycles_proven * 1000 / duration.as_millis();
-                let proof_cycles_per_minute = cycles_proven * 60 * 1000 / duration.as_millis();
+                let proof_cycles_hertz = cycles_proven as f64 * 1000.0 / duration.as_millis() as f64;
                 client
                     .send(Message::Binary(response.encode_to_vec()))
                     .await
                     .unwrap();                                               
                 track(
                     "proof".into(),
-                    format!("Proof sent! You proved at {} Hz.", proof_cycles_hertz),
+                    format!("Proof sent! Overall speed was {:.2} proof cycles/sec.", proof_cycles_hertz),
                     &ws_addr_string,
                     json!({
                         "proof_duration_sec": duration.as_secs(),
                         "proof_duration_millis": duration.as_millis(),
                         "proof_cycles_hertz": proof_cycles_hertz,
-                        "proof_cycles_per_minute": proof_cycles_per_minute,
                         "prover_id": prover_id,
                     }),
                 );


### PR DESCRIPTION
- [x] Show proving speed in cycles/minute with two decimals precision
- [x] Don't track cycles/minute
- [x] Update messaging around steps to prove
- [x] Don't send analytics at all in debug mode