### PR TITLE
update README file to support whoever runs with CLI

### DIFF
--- a/clients/cli/README.md
+++ b/clients/cli/README.md
@@ -44,6 +44,93 @@ The first time you run it, it prompts you to accept the terms. To accept the ter
 noninteractively (for example, in a continuous integration environment),
 add `NONINTERACTIVE=1` before `sh`.
 
+## Turning out the nexus process to run as a service (optional)
+
+Note: This will help anyone who runs cli whose process is stopped after a period of time, will be automatically restarted by systemd and continue the process without having to do it manually again.
+
+- Assume i'm staying at /root path (can be anywhere on your machine)
+- Download file script: curl https://cli.nexus.xyz/install.sh > nexus.sh
+
+#### Update `nexus.sh` file
+- To accept the terms noninteractively
+- Specify absolute path of cargo and rustc
+
+```
+sed -i 's|rustc|/root/.cargo/bin/rustc|g' nexus.sh
+sed -i 's|cargo|/root/.cargo/bin/cargo|g' nexus.sh
+
+sed -i '5i NONINTERACTIVE=1' nexus.sh
+```
+
+### Create a systemd service 
+`nano /etc/systemd/system/nexus.service`
+
+and input this configuration
+```
+[Unit]
+Description=Nexus Process
+After=network.target
+
+[Service]
+ExecStart=/root/nexus.sh  # <==== make sure to change this file location to match where you put the file
+Restart=on-failure
+RestartSec=5
+RestartPreventExitStatus=127
+SuccessExitStatus=127
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target
+```
+
+save and exit
+```
+ctrl + o (save)
+ctrl + x (exit the editor)
+```
+
+### Reload the systemd daemon
+```
+sudo systemctl daemon-reload
+```
+
+### Start and Enable the Service
+```
+sudo systemctl start nexus.service
+sudo systemctl enable nexus.service
+```
+
+### Check the Status (waiting for a few minutes to let it build the code)
+```
+sudo systemctl status nexus.service
+```
+something like this, this is ok
+```
+● nexus.service - Nexus Process
+     Loaded: loaded (/etc/systemd/system/nexus.service; enabled; vendor preset: enabled)
+     Active: active (running) since Sat 2024-10-26 16:23:13 CEST; 2min 16s ago
+   Main PID: 951443 (nexus.sh)
+      Tasks: 34 (limit: 77071)
+     Memory: 1.2G
+        CPU: 1min 14.009s
+     CGroup: /system.slice/nexus.service
+             ├─951443 /bin/sh /root/nexus/nexus.sh
+             └─951458 target/release/prover beta.orchestrator.nexus.xyz
+
+Oct 26 16:23:40 vmi2192653.contaboserver.net nexus.sh[951458]: Proved step 14 at 3.85 proof cycles/sec.
+Oct 26 16:23:41 vmi2192653.contaboserver.net nexus.sh[951458]: Proved step 15 at 4.16 proof cycles/sec.
+Oct 26 16:23:42 vmi2192653.contaboserver.net nexus.sh[951458]: Proved step 16 at 3.80 proof cycles/sec.
+```
+
+
+### Monitor the Logs
+```
+journalctl -u nexus.service -f
+
+ctrl + c to exit
+```
+
 ## Known issues
 
 * Only the latest version of the CLI is currently supported.


### PR DESCRIPTION
**Error**: `thread 'main' panicked at src/prover.rs:157:66:
called Result::unwrap() on an Err value: Protocol(ResetWithoutClosingHandshake)
note: run with RUST_BACKTRACE=1 environment variable to display a backtrace
thread 'tokio-runtime-worker' panicked at src/analytics.rs:52:14:
called Result::unwrap() on an Err value: reqwest::Error { kind: Request, url: Url { scheme: "https", cannot_be_a_base: false, username: "", password: None, host: Some(Domain("api.mixpanel.com")), port: None, path: "/track", query: Some("ip=1"), fragment: None }, source: hyper_util::client::legacy::Error(Connect, ConnectError("dns error", Custom { kind: Interrupted, error: JoinError::Cancelled(Id(133)) })) }`

**Purpose**: There will be an error for those who run using CLI, and the process will stop automatically after a while. You will have to run the command again. To avoid this, I suggest running a process as a service with systems.

**Tested**
![Screenshot 2024-10-26 221557](https://github.com/user-attachments/assets/13ca9c37-ee6f-4f8d-a6e5-da079597b236)


