### PR TITLE
chore: remove beta stats link

### DIFF
--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nexus-network"
-version = "0.1.0"
+version = "0.3.2"
 edition = "2021"
 
 [[bin]]

--- a/clients/cli/src/prover.rs
+++ b/clients/cli/src/prover.rs
@@ -150,9 +150,6 @@ async fn main() {
         &ws_addr_string,
         json!({"ws_addr_string": ws_addr_string, "prover_id": prover_id}),
     );
-    println!(
-        "Network stats are available at https://beta.nexus.xyz/."
-    );
     loop {
         let program_message = match client.next().await.unwrap().unwrap() {
             Message::Binary(b) => b,


### PR DESCRIPTION
Live network stats are offline as we prepare for the next beta.

Aggregate network stats from the current beta are available in the [retrospective blog post](https://blog.nexus.xyz/next-steps-for-nexus-network-beta/
).