### PR TITLE
chore: Don't send analytics during devnet

### DIFF
--- a/clients/cli/src/config.rs
+++ b/clients/cli/src/config.rs
@@ -7,11 +7,11 @@ pub fn analytics_token(_ws_addr_string: &str) -> String {
 #[cfg(not(debug_assertions))]
 pub fn analytics_token(ws_addr_string: &str) -> String {
     if ws_addr_string.starts_with("wss://dev.orchestrator.nexus.xyz:443/") {
-        return "504d4d443854f2cd10e2e385aca81aa4".into();
+        return "".into(); // TODO: Firebase Analytics tid
     } else if ws_addr_string.starts_with("wss://staging.orchestrator.nexus.xyz:443/") {
-        return "30bcb58893992aabc5aec014e7b903d2".into();
+        return "".into(); // TODO: Firebase Analytics tid
     } else if ws_addr_string.starts_with("wss://beta.orchestrator.nexus.xyz:443/") {
-        return "3c16d3853f4258414c9c9109bbbdef0e".into();
+        return "".into(); // TODO: Firebase Analytics tid
     } else {
         return "".into();
     };


### PR DESCRIPTION
In preparation for moving to Firebase Analytics, disable tracking.