### PR TITLE
feat: use firebase instead of mixpanel in for event tracking

### DIFF
--- a/clients/cli/Cargo.lock
+++ b/clients/cli/Cargo.lock
@@ -1567,7 +1567,7 @@ dependencies = [
 
 [[package]]
 name = "nexus-network"
-version = "0.1.0"
+version = "0.3.2"
 dependencies = [
  "ark-bn254",
  "ark-crypto-primitives",

--- a/clients/cli/src/analytics.rs
+++ b/clients/cli/src/analytics.rs
@@ -28,7 +28,7 @@ pub fn track(
     // we can use the Measurement Protocol to track events by POST to a URL. 
     // The only thing that may be unexpected is that the URL we use includes a firebase key
 
-    // Firebase format for properties for Mesurement protocol: 
+    // Firebase format for properties for Measurement protocol: 
     // https://developers.google.com/analytics/devguides/collection/protocol/ga4/reference?client_type=firebase#payload
     // https://developers.google.com/analytics/devguides/collection/protocol/ga4/reference?client_type=firebase#payload_query_parameters
     let mut properties = json!({

--- a/clients/cli/src/analytics.rs
+++ b/clients/cli/src/analytics.rs
@@ -1,4 +1,4 @@
-use crate::config::analytics_token;
+use crate::config::{analytics_token, analytics_api_secret};
 use chrono::Datelike;
 use chrono::Timelike;
 use reqwest::header::{ACCEPT, CONTENT_TYPE};
@@ -16,14 +16,27 @@ pub fn track(
 ) {
     println!("{}", description);
 
-    let token = analytics_token(ws_addr_string);
-    if token.is_empty() {
+    let firebase_app_id = analytics_token(ws_addr_string);
+    let firebase_api_secret = analytics_api_secret(ws_addr_string);
+    if firebase_app_id.is_empty() {
         return;
     }
     let local_now = chrono::offset::Local::now();
+
+    // For tracking events, we use the Firebase Measurement Protocol
+    // Firebase is mostly designed for mobile and web apps, but for our use case of a CLI,
+    // we can use the Measurement Protocol to track events by POST to a URL. 
+    // The only thing that may be unexpected is that the URL we use includes a firebase secret (something we dont typically add to client code)
+
+    // Firebase format for properties for Mesurement protocol: 
+    // https://developers.google.com/analytics/devguides/collection/protocol/ga4/reference?client_type=firebase#payload
+    // https://developers.google.com/analytics/devguides/collection/protocol/ga4/reference?client_type=firebase#payload_query_parameters
     let mut properties = json!({
-        "token": token,
         "time": SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_millis(),
+        // app_instance_id is the standard key Firebase uses this key to track the same user across sessions
+        // its is a bit redundant, but I wanted to keep the recommended format Firebase uses to minimize surprises
+        // I still left the distinct_id key as well for backwards compatibility
+        "app_instance_id": event_properties["prover_id"],  
         "distinct_id": event_properties["prover_id"],
         "prover_type": "volunteer",
         "client_type": "cli",
@@ -36,14 +49,26 @@ pub fn track(
     for (k, v) in event_properties.as_object().unwrap() {
         properties[k] = v.clone();
     }
+
+    // Firebase format for events
     let body = json!({
-        "event": event_name,
-        "properties": properties
+        "app_instance_id": event_properties["prover_id"],
+        "events": [{
+            "name": event_name,
+            "params": properties
+        }],
     });
+
     tokio::spawn(async move {
         let client = reqwest::Client::new();
+
         let _ = client
-            .post("https://api.mixpanel.com/track?ip=1")
+            //URL is the google analytics endpoint for firebase: https://stackoverflow.com/questions/50355752/firebase-analytics-from-remote-rest-api
+            .post(format!(
+                "https://www.google-analytics.com/mp/collect?firebase_app_id={}&api_secret={}",
+                firebase_app_id,
+                firebase_api_secret
+            ))
             .body(format!("[{}]", body.to_string()))
             .header(ACCEPT, "text/plain")
             .header(CONTENT_TYPE, "application/json")

--- a/clients/cli/src/analytics.rs
+++ b/clients/cli/src/analytics.rs
@@ -69,7 +69,7 @@ pub fn track(
                 firebase_app_id,
                 firebase_api_key
             ))
-            .body(format!("[{}]", body.to_string()))
+            .body(format!("[{}]", body))
             .header(ACCEPT, "text/plain")
             .header(CONTENT_TYPE, "application/json")
             .send()

--- a/clients/cli/src/analytics.rs
+++ b/clients/cli/src/analytics.rs
@@ -34,7 +34,7 @@ pub fn track(
     let mut properties = json!({
         "time": SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_millis(),
         // app_instance_id is the standard key Firebase uses this key to track the same user across sessions
-        // its is a bit redundant, but I wanted to keep the recommended format Firebase uses to minimize surprises
+        // It is a bit redundant, but I wanted to keep the recommended format Firebase uses to minimize surprises
         // I still left the distinct_id key as well for backwards compatibility
         "app_instance_id": event_properties["prover_id"],  
         "distinct_id": event_properties["prover_id"],

--- a/clients/cli/src/analytics.rs
+++ b/clients/cli/src/analytics.rs
@@ -63,7 +63,7 @@ pub fn track(
         let client = reqwest::Client::new();
 
         let _ = client
-            //URL is the google analytics endpoint for firebase: https://stackoverflow.com/questions/50355752/firebase-analytics-from-remote-rest-api
+            // URL is the Google Analytics endpoint for Firebase: https://stackoverflow.com/questions/50355752/firebase-analytics-from-remote-rest-api
             .post(format!(
                 "https://www.google-analytics.com/mp/collect?firebase_app_id={}&api_secret={}",
                 firebase_app_id,

--- a/clients/cli/src/analytics.rs
+++ b/clients/cli/src/analytics.rs
@@ -1,4 +1,4 @@
-use crate::config::{analytics_token, analytics_api_secret};
+use crate::config::{analytics_id, analytics_api_key};
 use chrono::Datelike;
 use chrono::Timelike;
 use reqwest::header::{ACCEPT, CONTENT_TYPE};
@@ -16,8 +16,8 @@ pub fn track(
 ) {
     println!("{}", description);
 
-    let firebase_app_id = analytics_token(ws_addr_string);
-    let firebase_api_secret = analytics_api_secret(ws_addr_string);
+    let firebase_app_id = analytics_id(ws_addr_string);
+    let firebase_api_key = analytics_api_key(ws_addr_string);
     if firebase_app_id.is_empty() {
         return;
     }
@@ -26,7 +26,7 @@ pub fn track(
     // For tracking events, we use the Firebase Measurement Protocol
     // Firebase is mostly designed for mobile and web apps, but for our use case of a CLI,
     // we can use the Measurement Protocol to track events by POST to a URL. 
-    // The only thing that may be unexpected is that the URL we use includes a firebase secret (something we dont typically add to client code)
+    // The only thing that may be unexpected is that the URL we use includes a firebase key
 
     // Firebase format for properties for Mesurement protocol: 
     // https://developers.google.com/analytics/devguides/collection/protocol/ga4/reference?client_type=firebase#payload
@@ -67,7 +67,7 @@ pub fn track(
             .post(format!(
                 "https://www.google-analytics.com/mp/collect?firebase_app_id={}&api_secret={}",
                 firebase_app_id,
-                firebase_api_secret
+                firebase_api_key
             ))
             .body(format!("[{}]", body.to_string()))
             .header(ACCEPT, "text/plain")

--- a/clients/cli/src/config.rs
+++ b/clients/cli/src/config.rs
@@ -1,6 +1,13 @@
-// This version is ONLY compiled when running in debug mode
+// Debug version of analytics_id
 #[cfg(debug_assertions)]
-pub fn analytics_token(_ws_addr_string: &str) -> String {
+pub fn analytics_id(_ws_addr_string: &str) -> String {
+    // Use one of the tokens in the release version if debugging analytics
+    return "".into();
+}
+
+// Debug version of analytics_api_key
+#[cfg(debug_assertions)]
+pub fn analytics_api_key(_ws_addr_string: &str) -> String {
     // Use one of the tokens in the release version if debugging analytics
     return "".into();
 }
@@ -30,15 +37,15 @@ mod firebase {
     pub const STAGING_APP_ID: &str = "1:222794630996:web:1758d64a85eba687eaaac1";
     pub const BETA_APP_ID: &str = "1:279395003658:web:04ee2c524474d683d75ef3";
 
-    // DUMMY VALUES FOR DEBUGGING, NOT REAL API SECRETS
+    // Analytics Secrets for the different environments
     pub const DEV_API_SECRET: &str = "85858585858585858585858585858585";
     pub const STAGING_API_SECRET: &str = "85858585858585858585858585858585";
-    pub const BETA_API_SECRET: &str = "85858585858585858585858585858585";
+    pub const BETA_API_SECRET: &str = "gxxzKAQLSl-uYI0eKbIi_Q";
 }
 
-// // This version is ONLY compiled when running in release mode
+// Release versions (existing code)
 #[cfg(not(debug_assertions))]
-pub fn analytics_token(ws_addr_string: &str) -> String {
+pub fn analytics_id(ws_addr_string: &str) -> String {
 
     // Determine the environment from the web socket string (ws_addr_string)
     let env = match ws_addr_string {
@@ -58,7 +65,7 @@ pub fn analytics_token(ws_addr_string: &str) -> String {
 }
 
 #[cfg(not(debug_assertions))]
-pub fn analytics_api_secret(ws_addr_string: &str) -> String {
+pub fn analytics_api_key(ws_addr_string: &str) -> String {
     match ws_addr_string {
         web_socket_urls::DEV => firebase::DEV_API_SECRET.to_string(),
         web_socket_urls::STAGING => firebase::STAGING_API_SECRET.to_string(),

--- a/clients/cli/src/config.rs
+++ b/clients/cli/src/config.rs
@@ -37,9 +37,11 @@ mod firebase {
     pub const STAGING_APP_ID: &str = "1:222794630996:web:1758d64a85eba687eaaac1";
     pub const BETA_APP_ID: &str = "1:279395003658:web:04ee2c524474d683d75ef3";
 
-    // Analytics Secrets for the different environments
-    pub const DEV_API_SECRET: &str = "85858585858585858585858585858585";
-    pub const STAGING_API_SECRET: &str = "85858585858585858585858585858585";
+    // Analytics keys for the different environments
+    // These are keys that allow the measurement protocol to write to the analytics database
+    // They are not sensitive. Worst case, if a malicious actor obtains the secret, they could potentially send false or misleading data to your GA4 property
+    pub const DEV_API_SECRET: &str = "8ySxiKrtT8a76zClqqO8IQ";
+    pub const STAGING_API_SECRET: &str = "OI7H53soRMSDWfJf1ittHQ";
     pub const BETA_API_SECRET: &str = "gxxzKAQLSl-uYI0eKbIi_Q";
 }
 

--- a/clients/cli/src/config.rs
+++ b/clients/cli/src/config.rs
@@ -9,7 +9,7 @@ pub fn analytics_id(_ws_addr_string: &str) -> String {
 #[cfg(debug_assertions)]
 pub fn analytics_api_key(_ws_addr_string: &str) -> String {
     // Use one of the tokens in the release version if debugging analytics
-    return "".into();
+    "".into()
 }
 
 // The following enum is used to determine the environment from the web socket string

--- a/clients/cli/src/config.rs
+++ b/clients/cli/src/config.rs
@@ -1,18 +1,69 @@
+// This version is ONLY compiled when running in debug mode
 #[cfg(debug_assertions)]
 pub fn analytics_token(_ws_addr_string: &str) -> String {
     // Use one of the tokens in the release version if debugging analytics
     return "".into();
 }
 
+// The following enum is used to determine the environment from the web socket string
+#[derive(Debug)]
+#[cfg(not(debug_assertions))]
+enum Environment {
+    Dev,
+    Staging,
+    Beta,
+    Unknown,
+}
+
+// The web socket addresses for the different environments
+#[cfg(not(debug_assertions))]
+mod web_socket_urls {
+    pub const DEV: &str = "wss://dev.orchestrator.nexus.xyz:443/";
+    pub const STAGING: &str = "wss://staging.orchestrator.nexus.xyz:443/";
+    pub const BETA: &str = "wss://beta.orchestrator.nexus.xyz:443/";
+}
+
+// the firebase APP IDS by environment
+#[cfg(not(debug_assertions))]
+mod firebase {
+    pub const DEV_APP_ID: &str = "1:954530464230:web:f0a14de14ef7bcdaa99627";
+    pub const STAGING_APP_ID: &str = "1:222794630996:web:1758d64a85eba687eaaac1";
+    pub const BETA_APP_ID: &str = "1:279395003658:web:04ee2c524474d683d75ef3";
+
+    // DUMMY VALUES FOR DEBUGGING, NOT REAL API SECRETS
+    pub const DEV_API_SECRET: &str = "85858585858585858585858585858585";
+    pub const STAGING_API_SECRET: &str = "85858585858585858585858585858585";
+    pub const BETA_API_SECRET: &str = "85858585858585858585858585858585";
+}
+
+// // This version is ONLY compiled when running in release mode
 #[cfg(not(debug_assertions))]
 pub fn analytics_token(ws_addr_string: &str) -> String {
-    if ws_addr_string.starts_with("wss://dev.orchestrator.nexus.xyz:443/") {
-        return "".into(); // TODO: Firebase Analytics tid
-    } else if ws_addr_string.starts_with("wss://staging.orchestrator.nexus.xyz:443/") {
-        return "".into(); // TODO: Firebase Analytics tid
-    } else if ws_addr_string.starts_with("wss://beta.orchestrator.nexus.xyz:443/") {
-        return "".into(); // TODO: Firebase Analytics tid
-    } else {
-        return "".into();
+
+    // Determine the environment from the web socket string (ws_addr_string)
+    let env = match ws_addr_string {
+        web_socket_urls::DEV => Environment::Dev,
+        web_socket_urls::STAGING => Environment::Staging,
+        web_socket_urls::BETA => Environment::Beta,
+        _ => Environment::Unknown,
     };
+    
+    // Return the appropriate Firebase App ID based on the environment
+    match env {
+        Environment::Dev => firebase::DEV_APP_ID.to_string(),
+        Environment::Staging => firebase::STAGING_APP_ID.to_string(),
+        Environment::Beta => firebase::BETA_APP_ID.to_string(),
+        Environment::Unknown => String::new(),
+    }
 }
+
+#[cfg(not(debug_assertions))]
+pub fn analytics_api_secret(ws_addr_string: &str) -> String {
+    match ws_addr_string {
+        web_socket_urls::DEV => firebase::DEV_API_SECRET.to_string(),
+        web_socket_urls::STAGING => firebase::STAGING_API_SECRET.to_string(),
+        web_socket_urls::BETA => firebase::BETA_API_SECRET.to_string(),
+        _ => String::new(),
+    }
+}
+


### PR DESCRIPTION
**Things to note:**

1. the `config.rs` file had some slight refactoring to make thing simpler to read (using enums, comments, etc...)
2. replacing mixpanel with Firebase, but not regular firebase, but the measurement protocol
3. Updated `analytics.rs` so that it has the payload stricture that firebase expects

**Why the measurement protocol?**

For tracking events, this PR uses the Firebase Measurement Protocol.

Firebase is mostly designed for mobile and web apps, but for our use case of a CLI, we can use the Measurement Protocol to track events by POST to a URL. 

Firebase format for properties for [Measurement protocol](https://developers.google.com/analytics/devguides/collection/protocol/ga4/reference?client_type=firebase#payload
)
