### PR TITLE
fix: remove network key from protobuf

### DIFF
--- a/clients/cli/src/generated/nexus.orchestrator.rs
+++ b/clients/cli/src/generated/nexus.orchestrator.rs
@@ -24,14 +24,11 @@ pub struct ClientProgramProofRequest {
     /// Duration of the proof in milliseconds.
     #[prost(int32, tag = "6")]
     pub proof_duration_millis: i32,
-    /// Network that this proof is intended for.
-    #[prost(enumeration = "Network", tag = "7")]
-    pub network: i32,
     /// Number of cycles per step.
-    #[prost(int32, tag = "8")]
+    #[prost(int32, tag = "7")]
     pub k: i32,
     /// Prover ID for CLI provers
-    #[prost(string, optional, tag = "9")]
+    #[prost(string, optional, tag = "8")]
     pub cli_prover_id: ::core::option::Option<::prost::alloc::string::String>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/clients/cli/src/prover.rs
+++ b/clients/cli/src/prover.rs
@@ -178,7 +178,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 proof_duration_millis: progress_duration.as_millis() as i32,
                 k,
                 cli_prover_id: Some(prover_id.clone()),
-                network: 0,
                 program_id: "fast-fib".to_string(),
                 client_id_token: None,
             };

--- a/proto/orchestrator.proto
+++ b/proto/orchestrator.proto
@@ -30,14 +30,11 @@ message ClientProgramProofRequest {
   // Duration of the proof in milliseconds.
   int32 proof_duration_millis = 6;
 
-  // Network that this proof is intended for.
-  Network network = 7;
-
   // Number of cycles per step.
-  int32 k = 8;
+  int32 k = 7;
 
   // Prover ID for CLI provers
-  optional string cli_prover_id = 9;
+  optional string cli_prover_id = 8;
 }
 
 message ClientProgramProofResponse {


### PR DESCRIPTION
this removes `network` from the protobuf for `ClientProgramProofRequest`