### PR TITLE
feat: 

### DIFF
--- a/clients/cli/README.md
+++ b/clients/cli/README.md
@@ -66,12 +66,12 @@ To run the CLI with tracing enabled, run:
 To test against dev environment of the orchestrator, run:
 
 ```sh
-cargo run -- wss://dev.orchestrator.nexus.xyz:443/prove
+cargo run -- dev.orchestrator.nexus.xyz
 ```
 
 To test against beta environment of the orchestrator, run:
 ```sh
-cargo run -- wss://beta.orchestrator.nexus.xyz:443/prove
+cargo run -- beta.orchestrator.nexus.xyz
 ```
 
 ## Resources

--- a/clients/cli/README.md
+++ b/clients/cli/README.md
@@ -62,13 +62,6 @@ cargo run --release
 
 To run the CLI with tracing enabled, run:
 
-
-To test against dev environment of the orchestrator, run:
-
-```sh
-cargo run -- dev.orchestrator.nexus.xyz
-```
-
 To test against beta environment of the orchestrator, run:
 ```sh
 cargo run -- beta.orchestrator.nexus.xyz

--- a/clients/cli/README.md
+++ b/clients/cli/README.md
@@ -53,6 +53,27 @@ add `NONINTERACTIVE=1` before `sh`.
 * Only proving is supported. Submitting programs to the network is in private beta.
 To request an API key, contact us at growth@nexus.xyz.
 
+## Building and running from source
+
+```
+cargo build
+cargo run --release
+```
+
+To run the CLI with tracing enabled, run:
+
+
+To test against dev environment of the orchestrator, run:
+
+```sh
+cargo run -- wss://dev.orchestrator.nexus.xyz:443/prove
+```
+
+To test against beta environment of the orchestrator, run:
+```sh
+cargo run -- wss://beta.orchestrator.nexus.xyz:443/prove
+```
+
 ## Resources
 
 * [Network FAQ](https://nexus.xyz/network#network-faqs)

--- a/clients/cli/src/prover.rs
+++ b/clients/cli/src/prover.rs
@@ -48,7 +48,7 @@ use std::io::Read;
 use zstd::stream::Encoder;
 
 // The interval at which to send updates to the orchestrator
-const UPDATE_INTERVAL: u64 = 5; // 3 minutes
+const UPDATE_INTERVAL_IN_SECONDS: u64 = 180; // 3 minutes
 
 #[derive(Parser, Debug)]
 struct Args {
@@ -212,7 +212,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             progress_time = Instant::now();
 
             //If it has been three minutes since the last orchestrator update, send the orchestator the update
-            if timer_since_last_orchestrator_update.elapsed().as_secs() > UPDATE_INTERVAL {
+            if timer_since_last_orchestrator_update.elapsed().as_secs() > UPDATE_INTERVAL_IN_SECONDS
+            {
                 println!(
                     "\tWill try sending update to orchestrator with interval queued_steps_proven: {}",
                     queued_steps_proven
@@ -231,18 +232,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 // Connection is verified working
                                 match client.send(Message::Binary(progress.encode_to_vec())).await {
                                     Ok(_) => {
-                                        println!("\t\tSuccesfully sent progress to orchestrator\n");
-                                        println!("{:#?}", progress);
+                                        // println!("\t\tSuccesfully sent progress to orchestrator\n");
+                                        // println!("{:#?}", progress);
 
                                         // Reset the queued values only after successful send
                                         queued_steps_proven = 0;
                                         queued_proof_duration_millis = 0;
                                     }
-                                    Err(e) => {
-                                        eprintln!(
-                                            "\t\tFailed to send message. Will try again next update: {:?}\n",
-                                            e
-                                        );
+                                    Err(_) => {
+                                        // eprintln!(
+                                        //     "\t\tFailed to send message. Will try again next update: {:?}\n",
+                                        //     e
+                                        // );
                                         client = match connect_to_orchestrator_with_limited_retry(
                                             &ws_addr_string,
                                             &prover_id,
@@ -250,11 +251,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                                         .await
                                         {
                                             Ok(new_client) => new_client,
-                                            Err(e) => {
-                                                eprintln!(
-                                                    "Failed to reconnect to orchestrator: {}",
-                                                    e
-                                                );
+                                            Err(_) => {
+                                                // eprintln!(
+                                                //     "Failed to reconnect to orchestrator: {}",
+                                                //     e
+                                                // );
                                                 // Continue using the existing client and try again next update
                                                 client
                                             }
@@ -266,9 +267,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                             }
                             //... and the pong was not received
                             _ => {
-                                println!(
-                                    "\t\tNo pong from websockets connection received. Will reconnect to orchestrator..."
-                                );
+                                // println!(
+                                //     "\t\tNo pong from websockets connection received. Will reconnect to orchestrator..."
+                                // );
                                 client = match connect_to_orchestrator_with_limited_retry(
                                     &ws_addr_string,
                                     &prover_id,
@@ -276,8 +277,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 .await
                                 {
                                     Ok(new_client) => new_client,
-                                    Err(e) => {
-                                        eprintln!("Failed to reconnect to orchestrator: {}", e);
+                                    Err(_) => {
+                                        // eprintln!("Failed to reconnect to orchestrator: {}", e);
                                         // Continue using the existing client and try again next update
                                         client
                                     }
@@ -286,11 +287,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         }
                     }
                     //The ping failed to send...
-                    Err(e) => {
-                        println!(
-                            "\t\tPing failed, will attempt to reconnect to orchestrator: {:?}",
-                            e
-                        );
+                    Err(_) => {
+                        // println!(
+                        //     "\t\tPing failed, will attempt to reconnect to orchestrator: {:?}",
+                        //     e
+                        // );
                         client = match connect_to_orchestrator_with_limited_retry(
                             &ws_addr_string,
                             &prover_id,
@@ -298,8 +299,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         .await
                         {
                             Ok(new_client) => new_client,
-                            Err(e) => {
-                                eprintln!("Failed to reconnect to orchestrator: {}", e);
+                            Err(_) => {
+                                // eprintln!("Failed to reconnect to orchestrator: {}", e);
                                 // Continue using the existing client and try again next update
                                 client
                             }

--- a/clients/cli/src/prover.rs
+++ b/clients/cli/src/prover.rs
@@ -207,47 +207,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
             //If it has been three minutes since the last orchestrator update, send the orchestator the update
             if timer_since_last_orchestrator_update.elapsed().as_secs() > 180 {
-                // Check connection and attempt to send message with retries
-                let mut retries = 0;
-                let max_retries = 5;
-                loop {
-                    // Check if client is still connected by attempting to send a ping
-                    if let Err(_) = client.send(Message::Ping(vec![])).await {
-                        // Connection lost, attempt to reconnect
-                        client =
-                            connect_to_orchestrator_with_retry(&ws_addr_string, &prover_id).await;
-                        track(
-                            "reconnect".into(),
-                            "Reconnected to orchestrator".into(),
-                            &ws_addr_string,
-                            json!({"prover_id": prover_id}),
-                        );
-                    }
+                // Check if client is still connected by attempting to send a ping
+                if let Err(_) = client.send(Message::Ping(vec![])).await {
+                    // Connection lost, attempt to reconnect
+                    client = connect_to_orchestrator_with_retry(&ws_addr_string, &prover_id).await;
+                }
 
-                    match client.send(Message::Binary(progress.encode_to_vec())).await {
-                        Ok(_) => break, // Message sent successfully
-                        Err(e) => {
-                            eprintln!(
-                                "Failed to send message: {:?}, attempt {}/{}",
-                                e,
-                                retries + 1,
-                                max_retries
-                            );
-
-                            retries += 1;
-                            if retries >= max_retries {
-                                eprintln!("Max retries reached, exiting...");
-                                break;
-                            }
-
-                            // Add a delay before retrying
-                            tokio::time::sleep(tokio::time::Duration::from_secs(u64::pow(
-                                2, retries,
-                            )))
-                            .await;
-                        }
+                match client.send(Message::Binary(progress.encode_to_vec())).await {
+                    Ok(_) => break, // Message sent successfully
+                    Err(e) => {
+                        eprintln!("Failed to send message: {:?}, attempt", e);
                     }
                 }
+
                 //reset the timer
                 timer_since_last_orchestrator_update = Instant::now()
             }


### PR DESCRIPTION
This PR 

## Current State of the world

This is the progress object that is sent to the orchestrator,

```
let progress = ClientProgramProofRequest {
               steps_in_trace: total_steps as i32,
               steps_proven,
               step_to_start: start as i32,
               program_id: "fast-fib".to_string(),
               client_id_token: None,
               proof_duration_millis: progress_duration.as_millis() as i32,
               k,
               cli_prover_id: Some(prover_id.clone()),
           };
```

Currently, it is sent to the orchestrator at each step. If offline, it currently retries 5 times and gives up

## This PR does the following:

Changes the logic so:

* `ClientProgramProofRequest` is now sent every 3 minutes, and not every step
* adds logic that checks if the websockets connection to orchestrator is lost. If lost, it tries 5 times. After the 5th time, it gives up and then tries again at the next interval (in 3 minutes).
* Store `proof_duration_millis` and `steps_proven in memory` and update `ClientProgramProofRequest` with the new variables.
* Batch the `ClientProgramProofRequest` objects being sent to the orchestrator 
* It assume it could take hours for connectivity to be back online
