### PR TITLE
feat: Prompt to set prover id

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,14 @@ Use of the CLI is subject to the [Terms of Use](https://nexus.xyz/terms-of-use).
 NONINTERACTIVE=1 sh
 ```
 
+## Prover Id
+
+The CLI will prompt for your web prover id from [beta.nexus.xyz](https://beta.nexus.xyz/)
+It is ok to skip this prompt and a random id will be generated, but you'll be
+prompted again on startup until your web prover id is entered.
+
+The prompt is disabled when NONINTERACTIVE=1 is set.
+
 ## Current Limitations
 
 - Only latest CLI version is supported

--- a/README.md
+++ b/README.md
@@ -47,10 +47,11 @@ NONINTERACTIVE=1 sh
 ## Prover Id
 
 The CLI will prompt for your web prover id from [beta.nexus.xyz](https://beta.nexus.xyz/)
-It is ok to skip this prompt and a random id will be generated, but you'll be
+on startup. It is ok to skip this prompt and a random id will be generated, but you'll be
 prompted again on startup until your web prover id is entered.
 
-The prompt is disabled when NONINTERACTIVE=1 is set.
+The prover id prompt is disabled when NONINTERACTIVE=1 is set. In a server environment,
+you can manually overwrite $HOME/.nexus/prover-id with your full prover id.
 
 ## Current Limitations
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ NONINTERACTIVE=1 sh
 
 - Only latest CLI version is supported
 - No prebuilt binaries yet
-- Email linking available on web only
 - Proof cycle counting coming soon
 - Program submission requires API key (contact growth@nexus.xyz)
 

--- a/clients/cli/src/prover.rs
+++ b/clients/cli/src/prover.rs
@@ -111,7 +111,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     track(
         "register".into(),
-        format!("Your assigned prover identifier is {}.", prover_id),
+        format!("Your current prover identifier is {}.", prover_id),
         &ws_addr_string,
         json!({"ws_addr_string": ws_addr_string, "prover_id": prover_id}),
     );

--- a/public/install.sh
+++ b/public/install.sh
@@ -20,7 +20,7 @@ if [ $GIT_IS_AVAILABLE != 0 ]; then
   exit 1;
 fi
 
-PROVER_ID=$(cat $NEXUS_HOME/prover-id 2>&1 || echo)
+PROVER_ID=$(cat $NEXUS_HOME/prover-id 2>/dev/null)
 if [ -z "$NONINTERACTIVE" ] && [ "${#PROVER_ID}" -ne "28" ]; then
     echo To receive credit for proving in Nexus testnets, click on your prover id
     echo at https://beta.nexus.xyz/ to copy the full prover id and paste it here.

--- a/public/install.sh
+++ b/public/install.sh
@@ -23,8 +23,8 @@ fi
 PROVER_ID=$(cat $NEXUS_HOME/prover-id 2>/dev/null)
 if [ -z "$NONINTERACTIVE" ] && [ "${#PROVER_ID}" -ne "28" ]; then
     echo To receive credit for proving in Nexus testnets, click on your prover id
-    echo at https://beta.nexus.xyz/ (lower left corner, or in the menu on mobile)
-    echo to copy the full prover id and paste it here. Press Enter to continue.
+    echo (bottom left) at https://beta.nexus.xyz/ to copy the full prover id and
+    echo paste it here. Press Enter to continue.
     read -p "Prover Id (optional)> " PROVER_ID </dev/tty
     while [ ! ${#PROVER_ID} -eq "0" ]; do
         if [ ${#PROVER_ID} -eq "28" ]; then

--- a/public/install.sh
+++ b/public/install.sh
@@ -20,6 +20,28 @@ if [ $GIT_IS_AVAILABLE != 0 ]; then
   exit 1;
 fi
 
+PROVER_ID=$(cat $NEXUS_HOME/prover-id 2>&1 || echo)
+if [ -z "$NONINTERACTIVE" ] && [ "${#PROVER_ID}" -ne "28" ]; then
+    echo To receive credit for proving to Nexus testnets, click on your prover id
+    echo at https://beta.nexus.xyz/ to copy the full prover id and paste it here.
+    echo Press Enter to continue.
+    read -p "Prover Id (optional)> " PROVER_ID </dev/tty
+    while [ ! ${#PROVER_ID} -eq "0" ]; do
+        if [ ${#PROVER_ID} -eq "28" ]; then
+            if [ -f "$NEXUS_HOME/prover-id" ]; then
+                echo Copying $NEXUS_HOME/prover-id to $NEXUS_HOME/prover-id.bak
+                cp $NEXUS_HOME/prover-id $NEXUS_HOME/prover-id.bak
+            fi
+            echo Saving $NEXUS_HOME/prover-id.
+            echo "$PROVER_ID" > $NEXUS_HOME/prover-id
+            break;
+        else
+            echo Unable to validate $PROVER_ID. Please make sure the full prover id is copied.
+        fi
+        read -p "Prover Id (optional)> " PROVER_ID </dev/tty
+    done
+fi
+
 REPO_PATH=$NEXUS_HOME/network-api
 if [ -d "$REPO_PATH" ]; then
   echo "$REPO_PATH exists. Updating.";

--- a/public/install.sh
+++ b/public/install.sh
@@ -22,7 +22,7 @@ fi
 
 PROVER_ID=$(cat $NEXUS_HOME/prover-id 2>&1 || echo)
 if [ -z "$NONINTERACTIVE" ] && [ "${#PROVER_ID}" -ne "28" ]; then
-    echo To receive credit for proving to Nexus testnets, click on your prover id
+    echo To receive credit for proving in Nexus testnets, click on your prover id
     echo at https://beta.nexus.xyz/ to copy the full prover id and paste it here.
     echo Press Enter to continue.
     read -p "Prover Id (optional)> " PROVER_ID </dev/tty
@@ -32,8 +32,8 @@ if [ -z "$NONINTERACTIVE" ] && [ "${#PROVER_ID}" -ne "28" ]; then
                 echo Copying $NEXUS_HOME/prover-id to $NEXUS_HOME/prover-id.bak
                 cp $NEXUS_HOME/prover-id $NEXUS_HOME/prover-id.bak
             fi
-            echo Saving $NEXUS_HOME/prover-id.
             echo "$PROVER_ID" > $NEXUS_HOME/prover-id
+            echo Prover id saved to $NEXUS_HOME/prover-id.
             break;
         else
             echo Unable to validate $PROVER_ID. Please make sure the full prover id is copied.

--- a/public/install.sh
+++ b/public/install.sh
@@ -23,8 +23,8 @@ fi
 PROVER_ID=$(cat $NEXUS_HOME/prover-id 2>/dev/null)
 if [ -z "$NONINTERACTIVE" ] && [ "${#PROVER_ID}" -ne "28" ]; then
     echo To receive credit for proving in Nexus testnets, click on your prover id
-    echo at https://beta.nexus.xyz/ to copy the full prover id and paste it here.
-    echo Press Enter to continue.
+    echo at https://beta.nexus.xyz/ (lower left corner, or in the menu on mobile)
+    echo to copy the full prover id and paste it here. Press Enter to continue.
     read -p "Prover Id (optional)> " PROVER_ID </dev/tty
     while [ ! ${#PROVER_ID} -eq "0" ]; do
         if [ ${#PROVER_ID} -eq "28" ]; then


### PR DESCRIPTION
If this CLI instance doesn't already have a web prover id, ask for the web prover id on startup.

This has to be in install.sh because it reads in input and is in a pipe to sh command.

**Steps to test**

1. cd into your checkout of network-api.
2. git checkout collinjackson/set-cli-client-id
3. cat ./public/install.sh | sh

![Screenshot 2024-11-25 at 2 36 22 PM](https://github.com/user-attachments/assets/d3be7ea1-68df-43f0-9786-b36093d406c0)
