### PR TITLE
hotfix: update error logging of the updater error

### DIFF
--- a/clients/cli/src/updater.rs
+++ b/clients/cli/src/updater.rs
@@ -52,10 +52,10 @@ pub fn spawn_auto_update_thread(
                     // ... there is an update available, try to apply it
                     VersionStatus::UpdateAvailable(new_version) => {
                         if let Err(e) = version_manager_thread.apply_update(&new_version) {
-                            eprintln!(
+                            println!(
                                 "{}[auto-updater]{} Failed to update CLI: {}",
                                 BLUE, RESET, e
-                            );
+                            )
                         }
                     }
                     // ... No update needed

--- a/clients/cli/src/utils/updater.rs
+++ b/clients/cli/src/utils/updater.rs
@@ -24,7 +24,7 @@ pub const RESET: &str = "\x1b[0m"; // Reset color
 // The file to store the current version in
 pub const VERSION_FILE: &str = ".current_version";
 pub const REMOTE_REPO: &str = "https://github.com/nexus-xyz/network-api";
-pub const FALLBACK_VERSION: Version = Version::new(0, 3, 5); // 0.3.5
+pub const FALLBACK_VERSION: Version = Version::new(0, 3, 6); // 0.3.6
 
 #[derive(Debug, Clone, Copy, PartialEq, clap::ValueEnum)]
 pub enum AutoUpdaterMode {
@@ -52,7 +52,7 @@ impl UpdaterConfig {
                     std::env::var("HOME").unwrap_or_default()
                 ),
                 remote_repo: String::from("https://github.com/nexus-xyz/network-api.git"),
-                update_interval: 300, // check for updates every 5 minutes (300 seconds)
+                update_interval: 3600, // check for updates every 1 hour (3600 seconds)
                 hostname,
             },
             AutoUpdaterMode::Test => Self {


### PR DESCRIPTION
This PR does two things:

1. There is an error in the `updater.rs` that is red and scary, but is actually harmless (at this stage). This PR changes the color so it seems more representative.

2. The updater currently runs every 5 minutes (this was the intent for the 1st day so we can observe). The long-running intent is to have it run every hour. So the PR updates the time to 1 hour (the long-running intent).