### PR TITLE
feat: make default program sticky

### DIFF
--- a/clients/cli/Cargo.lock
+++ b/clients/cli/Cargo.lock
@@ -1630,7 +1630,7 @@ dependencies = [
 
 [[package]]
 name = "nexus-network"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "ark-bn254",
  "ark-crypto-primitives",

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nexus-network"
-version = "0.3.6"
+version = "0.3.7"
 edition = "2021"
 
 [[bin]]

--- a/clients/cli/src/prover.rs
+++ b/clients/cli/src/prover.rs
@@ -51,7 +51,7 @@ use std::fs::File;
 use std::io::Read;
 use zstd::stream::Encoder;
 
-use crate::utils::updater::{AutoUpdaterMode, UpdaterConfig};
+use crate::utils::updater::AutoUpdaterMode;
 
 // The interval at which to send updates to the orchestrator
 const PROOF_PROGRESS_UPDATE_INTERVAL_IN_SECONDS: u64 = 180; // 3 minutes

--- a/clients/cli/src/prover.rs
+++ b/clients/cli/src/prover.rs
@@ -108,13 +108,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         args.port
     );
 
-    // Initialize the CLI auto-updater that checks for and applies updates to the CLI:
-    // a. Create the updater config
-    let updater_config = UpdaterConfig::new(args.updater_mode, args.hostname);
-
-    // b. runs the CLI's auto updater in a separate thread continuously in intervals
-    updater::spawn_auto_update_thread(&updater_config).expect("Failed to spawn auto-update thread");
-
     let k = 4;
     // TODO(collinjackson): Get parameters from a file or URL.
     let pp = gen_vm_pp::<C1, seq::SetupParams<(G1, G2, C1, C2, RO, SC)>>(k as usize, &())

--- a/clients/cli/src/prover.rs
+++ b/clients/cli/src/prover.rs
@@ -172,7 +172,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let mut rng = rand::thread_rng();
         let input = vec![5, rng.gen::<u8>(), rng.gen::<u8>()];
 
-        let program_name = utils::prover::get_random_program();
+        let program_name = utils::prover::get_program_for_prover(&prover_id);
         let program_file_path = &format!("src/generated/{}", program_name);
 
         let mut vm: NexusVM<MerkleTrie> =

--- a/clients/cli/src/updater.rs
+++ b/clients/cli/src/updater.rs
@@ -19,6 +19,9 @@ use crate::utils::updater::{UpdaterConfig, VersionManager, VersionStatus, BLUE, 
 // 1. The update checker can continuously monitor for new versions without interrupting the main CLI operations
 // 2. The main thread remains free to handle its primary responsibility (proving transactions)
 // 3. Users don't have to wait for update checks to complete before using the CLI
+
+// TODO(dprats): remove dead code allowing and use this function in the prover
+#[allow(dead_code)]
 pub fn spawn_auto_update_thread(
     updater_config: &UpdaterConfig,
 ) -> Result<(), Box<dyn std::error::Error>> {

--- a/clients/cli/src/utils/prover.rs
+++ b/clients/cli/src/utils/prover.rs
@@ -3,7 +3,7 @@ use std::hash::{Hash, Hasher};
 
 // Distribution percentage (0.0 to 1.0) for the cancer-diagnostic program
 // Example: 0.01 = 1%, 0.5 = 50%, 1.0 = 100%
-const CANCER_DIAGNOSTIC_PERCENTAGE: f32 = 0.50;
+const CANCER_DIAGNOSTIC_PERCENTAGE: f32 = 0.01;
 
 pub fn get_program_for_prover(prover_id: &str) -> String {
     // Create a deterministic hash from the prover_id

--- a/clients/cli/src/utils/prover.rs
+++ b/clients/cli/src/utils/prover.rs
@@ -1,14 +1,26 @@
-const CANCER_DIAGNOSTIC_PROBABILITY: f32 = 0.01;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
 
-pub fn get_random_program() -> String {
-    // There are two programs to choose from, with some % chance of using the cancer diagnostic program
-    let programs = ["fast-fib", "cancer-diagnostic"];
+// Distribution percentage (0.0 to 1.0) for the cancer-diagnostic program
+// Example: 0.01 = 1%, 0.5 = 50%, 1.0 = 100%
+const CANCER_DIAGNOSTIC_PERCENTAGE: f32 = 0.50;
 
-    let program_name = if rand::random::<f32>() < CANCER_DIAGNOSTIC_PROBABILITY {
-        programs[1]
+pub fn get_program_for_prover(prover_id: &str) -> String {
+    // Create a deterministic hash from the prover_id
+    let mut hasher = DefaultHasher::new();
+    prover_id.hash(&mut hasher);
+    let deterministic_hash = hasher.finish();
+
+    // Convert percentage (e.g., 0.01) to a number between 0-99
+    // Example: 0.01 -> 1, 0.5 -> 50
+    let percentage_of_cancer_program_in_programs = (CANCER_DIAGNOSTIC_PERCENTAGE * 100.0) as u64;
+
+    // If hash mod 100 falls below percentage, select cancer-diagnostic
+    let program_name = if deterministic_hash % 100 < percentage_of_cancer_program_in_programs {
+        "cancer-diagnostic" // Selected with CANCER_DIAGNOSTIC_PERCENTAGE chance
     } else {
-        programs[0]
+        "fast-fib" // Selected for remaining percentage
     };
 
-    format!("src/generated/{}", program_name)
+    program_name.to_string()
 }

--- a/clients/cli/src/utils/updater.rs
+++ b/clients/cli/src/utils/updater.rs
@@ -255,7 +255,7 @@ impl VersionManager {
 
         // debug output
         println!(
-            "{}[auto-updater thread]{} Checking for updates from: {}",
+            "{}[auto-updater]{} Checking for updates from: {}",
             BLUE, RESET, self.config.remote_repo
         );
 
@@ -263,7 +263,7 @@ impl VersionManager {
             Ok(version) => version,
             Err(e) => {
                 println!(
-                    "{}[auto-updater thread]{} Version check failed: {}",
+                    "{}[auto-updater]{} Version check failed: {}",
                     BLUE, RESET, e
                 );
                 return Ok(VersionStatus::UpToDate); // Gracefully handle error by assuming up-to-date


### PR DESCRIPTION
This PR does a few things:

## Primary intent

- when a user gets a prover-id, it is used to determine what program they should use for proving.

This is done by doing the following:
- make a hash of the prover id 
- modulo the hash by 100
- if the resulting number is beneath the threshold, then it chooses the cancer diagnostic program

## Secondary intent

- remove the updater for now
- bump version number in cargo <-- old chore