### PR TITLE
feat: add highlighting in the install script

### DIFF
--- a/public/install.sh
+++ b/public/install.sh
@@ -2,6 +2,9 @@
 
 rustc --version || curl https://sh.rustup.rs -sSf | sh
 NEXUS_HOME=$HOME/.nexus
+GREEN='\033[1;32m'
+ORANGE='\033[1;33m'
+NC='\033[0m' # No Color
 
 while [ -z "$NONINTERACTIVE" ] && [ ! -f "$NEXUS_HOME/prover-id" ]; do
     read -p "Do you agree to the Nexus Beta Terms of Use (https://nexus.xyz/terms-of-use)? (Y/n) " yn </dev/tty
@@ -22,10 +25,11 @@ fi
 
 PROVER_ID=$(cat $NEXUS_HOME/prover-id 2>/dev/null)
 if [ -z "$NONINTERACTIVE" ] && [ "${#PROVER_ID}" -ne "28" ]; then
-    echo To receive credit for proving in Nexus testnets, click on your prover id
-    echo "(bottom left) at https://beta.nexus.xyz/ to copy the full prover id and"
-    echo paste it here. Press Enter to continue.
-    read -p "Prover Id (optional)> " PROVER_ID </dev/tty
+    echo "\nTo receive credit for proving in Nexus testnets..."
+    echo "\t1. Go to ${GREEN}https://beta.nexus.xyz${NC}"
+    echo "\t2. On the bottom left hand corner, copy the ${ORANGE}prover id${NC}"
+    echo "\t3. Paste the ${ORANGE}prover id${NC} here. Press Enter to continue.\n"
+    read -p "Enter your Prover Id (optional)> " PROVER_ID </dev/tty
     while [ ! ${#PROVER_ID} -eq "0" ]; do
         if [ ${#PROVER_ID} -eq "28" ]; then
             if [ -f "$NEXUS_HOME/prover-id" ]; then


### PR DESCRIPTION
Users were not seeing the instructions for the prover ID. This CLI adds some copy and format changes to the install script. See below:

<img width="1081" alt="Screenshot 2024-12-06 at 2 14 35 PM" src="https://github.com/user-attachments/assets/c26dac5d-2b02-40a7-8df5-c326acf7a464">
