### PR TITLE
[Docker Support]CLI add docker deploy

### DIFF
--- a/clients/Dockerfile
+++ b/clients/Dockerfile
@@ -1,0 +1,30 @@
+FROM rust:bullseye AS builder
+
+RUN apt update && \
+    apt install -y build-essential pkg-config libssl-dev protobuf-compiler && \
+    mkdir /root/.nexus && \
+    cd /root/.nexus && \
+    git clone https://github.com/nexus-xyz/network-api && \
+    cd network-api && \
+    git -c advice.detachedHead=false checkout $(git rev-list --tags --max-count=1)
+
+WORKDIR /root/.nexus/network-api/clients/cli
+
+RUN cargo build --release --bin prover
+
+FROM debian:bullseye-slim
+
+RUN apt update && \
+    apt install -y ca-certificates && \
+    mkdir /root/.nexus
+
+COPY --from=builder /root/.nexus/network-api/clients/cli/src /root/.nexus/src
+COPY --from=builder /root/.nexus/network-api/clients/cli/target/release/prover /root/.nexus/prover
+
+WORKDIR /root/.nexus
+
+COPY entrypoint.sh .
+
+RUN chmod +x entrypoint.sh
+
+CMD ["./entrypoint.sh", "./prover", "beta.orchestrator.nexus.xyz"]

--- a/clients/entrypoint.sh
+++ b/clients/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+if [ -z "${PROVER_ID}" ]; then
+    echo "Error: PROVER_ID environment variable is not set or is empty"
+    exit 1
+fi
+
+NEXUS_HOME=$HOME/.nexus
+echo "$PROVER_ID" > $NEXUS_HOME/prover-id
+
+exec "$@"


### PR DESCRIPTION
Deploying with docker reduces unnecessary dependency errors, and you only need to update the image for each update