### PR TITLE
fix: fix writing prover-id to file and reading it

### DIFF
--- a/clients/cli/src/prover.rs
+++ b/clients/cli/src/prover.rs
@@ -117,6 +117,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let prover_id = prover_id_manager::get_or_generate_prover_id();
 
     println!(
+        "\t✔ Your current prover identifier is {}",
+        prover_id.bright_cyan()
+    );
+
+    println!(
         "\n===== {}...\n",
         "Connecting to Nexus Network".bold().underline()
     );
@@ -131,11 +136,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Connect to the Orchestrator with exponential backoff
     let mut client = connect_to_orchestrator_with_infinite_retry(&ws_addr_string, &prover_id).await;
-
-    println!(
-        "\t✔ Your current prover identifier is {}",
-        prover_id.bright_cyan()
-    );
 
     println!(
         "\n{}",

--- a/clients/cli/src/prover.rs
+++ b/clients/cli/src/prover.rs
@@ -117,7 +117,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let prover_id = prover_id_manager::get_or_generate_prover_id();
 
     println!(
-        "\t✔ Your current prover identifier is {}",
+        "\n\t✔ Your current prover identifier is {}",
         prover_id.bright_cyan()
     );
 

--- a/clients/cli/src/prover_id_manager.rs
+++ b/clients/cli/src/prover_id_manager.rs
@@ -16,15 +16,19 @@ pub fn get_or_generate_prover_id() -> String {
     let nexus_dir = home_path.join(".nexus");
     let prover_id_path = nexus_dir.join("prover-id");
 
+    // 1. If the .nexus directory doesn't exist, we need to create it
     if !nexus_dir.exists() {
         return handle_first_time_setup(&nexus_dir, &prover_id_path, &default_prover_id);
     }
 
+    // 2. If the .nexus directory exists, we need to read the prover-id file
     match read_existing_prover_id(&prover_id_path) {
+        // 2.1 Happy path - we successfully read the prover-id file
         Ok(id) => {
             println!("Successfully read existing prover-id from file: {}", id);
             id
         }
+        // 2.2 We couldn't read the prover-id file, so we may need to create a new one
         Err(e) => {
             eprintln!(
                 "{}: {}",

--- a/clients/cli/src/prover_id_manager.rs
+++ b/clients/cli/src/prover_id_manager.rs
@@ -5,8 +5,7 @@ use std::{fs, path::Path};
 
 /// Gets an existing prover ID from the filesystem or generates a new one
 pub fn get_or_generate_prover_id() -> String {
-    // If the prover_id file is found, use the contents, otherwise generate a new random id
-    // and store it. e.g., "happy-cloud-42"
+    // Generate default ID that we'll use if we can't read/write a saved one
     let default_prover_id: String = format!(
         "{}-{}-{}",
         random_word::gen(Lang::En),
@@ -14,68 +13,112 @@ pub fn get_or_generate_prover_id() -> String {
         rand::thread_rng().next_u32() % 100,
     );
 
-    // setting the prover-id we will use (either from the file or generated)
-    let prover_id: String = match home::home_dir() {
-        Some(path) if !path.as_os_str().is_empty() => {
-            let nexus_dir = Path::new(&path).join(".nexus");
+    let home_path = match home::home_dir() {
+        Some(path) if !path.as_os_str().is_empty() => path,
+        _ => {
+            println!(
+                "Could not determine home directory, using temporary prover-id: {}",
+                default_prover_id
+            );
+            return default_prover_id;
+        }
+    };
 
-            // Try to read the prover-id file
-            match fs::read(nexus_dir.join("prover-id")) {
-                // 1. If file exists and can be read:
-                Ok(buf) => match String::from_utf8(buf) {
-                    Ok(id) => id.trim().to_string(), // Trim whitespace
-                    Err(e) => {
-                        eprintln!("Failed to read prover-id file. Using default: {}", e);
-                        default_prover_id // Fall back to generated ID, if file has invalid UTF-8
+    let nexus_dir = home_path.join(".nexus");
+    let prover_id_path = nexus_dir.join("prover-id");
+
+    // First check if .nexus directory exists
+    if !nexus_dir.exists() {
+        println!("Attempting to create .nexus directory");
+        if let Err(e) = fs::create_dir(&nexus_dir) {
+            eprintln!(
+                "{}: {}",
+                "Warning: Failed to create .nexus directory"
+                    .to_string()
+                    .yellow(),
+                e
+            );
+            return default_prover_id;
+        }
+        println!("Successfully created .nexus directory");
+
+        // Save the new prover ID
+        if let Err(e) = fs::write(&prover_id_path, &default_prover_id) {
+            println!("Failed to save prover-id to file: {}", e);
+            return default_prover_id;
+        }
+        println!(
+            "Successfully saved new prover-id to file: {}",
+            default_prover_id
+        );
+        return default_prover_id;
+    }
+
+    // .nexus exists, try to read prover-id file
+    match fs::read(&prover_id_path) {
+        Ok(buf) => match String::from_utf8(buf) {
+            Ok(id) => {
+                println!("Successfully read existing prover-id from file: {}", id);
+                id.trim().to_string()
+            }
+            Err(e) => {
+                println!(
+                    "Found file but content is not valid UTF-8, using default. Error: {}",
+                    e
+                );
+                default_prover_id
+            }
+        },
+        Err(e) => {
+            eprintln!(
+                "{}: {}",
+                "Warning: Could not read prover-id file"
+                    .to_string()
+                    .yellow(),
+                e
+            );
+
+            match e.kind() {
+                std::io::ErrorKind::NotFound => {
+                    // File doesn't exist in existing .nexus directory, create it
+                    if let Err(e) = fs::write(&prover_id_path, &default_prover_id) {
+                        println!("Failed to save prover-id to file: {}", e);
+                    } else {
+                        println!(
+                            "Successfully saved new prover-id to file: {}",
+                            default_prover_id
+                        );
                     }
-                },
-                // 2. If file doesn't exist or can't be read:
-                Err(e) => {
+                }
+                std::io::ErrorKind::PermissionDenied => {
                     eprintln!(
                         "{}: {}",
-                        "Warning: Could not read prover-id file"
+                        "Error: Permission denied when accessing prover-id file"
                             .to_string()
                             .yellow(),
                         e
                     );
-
-                    // if the error is because the file doesn't exist
-                    // Try to save the generated prover-id to the file
-                    if e.kind() == std::io::ErrorKind::NotFound {
-                        // Try to create the .nexus directory
-                        match fs::create_dir(nexus_dir.clone()) {
-                            Ok(_) => {
-                                // Only try to write file if directory was created successfully
-                                if let Err(e) =
-                                    fs::write(nexus_dir.join("prover-id"), &default_prover_id)
-                                {
-                                    eprintln!("Warning: Could not save prover-id: {}", e);
-                                }
-                            }
-                            Err(e) => {
-                                eprintln!(
-                                    "{}: {}",
-                                    "Warning: Failed to create .nexus directory"
-                                        .to_string()
-                                        .yellow(),
-                                    e
-                                );
-                            }
-                        }
-                    }
-
-                    // Use the previously generated prover-id
-                    default_prover_id
+                }
+                std::io::ErrorKind::InvalidData => {
+                    eprintln!(
+                        "{}: {}",
+                        "Error: Prover-id file is corrupted".to_string().yellow(),
+                        e
+                    );
+                }
+                _ => {
+                    eprintln!(
+                        "{}: {}",
+                        "Error: Unexpected IO error when reading prover-id file"
+                            .to_string()
+                            .yellow(),
+                        e
+                    );
                 }
             }
-        }
-        _ => {
-            println!("Unable to determine home directory. Using temporary prover-id.");
             default_prover_id
         }
-    };
-
-    prover_id
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Issue
The CLI wasn't saving autogenerated prover IDs in certain error cases. When reading the prover ID file failed, some error paths didn't properly handle saving the default ID.

## Primary changes
- Refactored `get_or_generate_prover_id` to handle some missing cases (e.g. hitting an error, missing file, etc...)
- Since there are a few cases, refactored the function into smaller functions that are used by the particular case (or re-used as appropriater)
- Simplified error handling to ensure consistent behavior
- Added test coverage for empty file scenarios

# Secondary changes
- Moved a print statement so `Your current prover identifier is` shows up in the `Setting up CLI configuration.` section (see image below). Before this PR, the prover id was logged in same section as the web socket connection. This was misleading.

<img width="932" alt="Screenshot 2024-12-09 at 10 59 12 AM" src="https://github.com/user-attachments/assets/14438eae-5935-4c75-9511-92dfc08c9011">
