### PR TITLE
fix: CLI analytics fix

### DIFF
--- a/clients/cli/src/config.rs
+++ b/clients/cli/src/config.rs
@@ -1,5 +1,20 @@
+// Debug version of analytics_id
+#[cfg(debug_assertions)]
+pub fn analytics_id(_ws_addr_string: &str) -> String {
+    // Use one of the tokens in the release version if debugging analytics
+    "".into()
+}
+
+// Debug version of analytics_api_key
+#[cfg(debug_assertions)]
+pub fn analytics_api_key(_ws_addr_string: &str) -> String {
+    // Use one of the tokens in the release version if debugging analytics
+    "".into()
+}
+
 // The following enum is used to determine the environment from the web socket string
 #[derive(Debug)]
+#[cfg(not(debug_assertions))]
 enum Environment {
     Dev,
     Staging,
@@ -8,6 +23,7 @@ enum Environment {
 }
 
 // The web socket addresses for the different environments
+#[cfg(not(debug_assertions))]
 mod web_socket_urls {
     pub const DEV: &str = "wss://dev.orchestrator.nexus.xyz:443/prove";
     pub const STAGING: &str = "wss://staging.orchestrator.nexus.xyz:443/prove";
@@ -15,6 +31,7 @@ mod web_socket_urls {
 }
 
 // the firebase APP IDS by environment
+#[cfg(not(debug_assertions))]
 mod firebase {
     pub const DEV_APP_ID: &str = "1:954530464230:web:f0a14de14ef7bcdaa99627";
     pub const STAGING_APP_ID: &str = "1:222794630996:web:1758d64a85eba687eaaac1";
@@ -29,6 +46,7 @@ mod firebase {
 }
 
 // Release versions (existing code)
+#[cfg(not(debug_assertions))]
 pub fn analytics_id(ws_addr_string: &str) -> String {
     // Determine the environment from the web socket string (ws_addr_string)
     let env = match ws_addr_string {
@@ -47,6 +65,7 @@ pub fn analytics_id(ws_addr_string: &str) -> String {
     }
 }
 
+#[cfg(not(debug_assertions))]
 pub fn analytics_api_key(ws_addr_string: &str) -> String {
     match ws_addr_string {
         web_socket_urls::DEV => firebase::DEV_API_SECRET.to_string(),

--- a/clients/cli/src/config.rs
+++ b/clients/cli/src/config.rs
@@ -1,20 +1,5 @@
-// Debug version of analytics_id
-#[cfg(debug_assertions)]
-pub fn analytics_id(_ws_addr_string: &str) -> String {
-    // Use one of the tokens in the release version if debugging analytics
-    "".into()
-}
-
-// Debug version of analytics_api_key
-#[cfg(debug_assertions)]
-pub fn analytics_api_key(_ws_addr_string: &str) -> String {
-    // Use one of the tokens in the release version if debugging analytics
-    "".into()
-}
-
 // The following enum is used to determine the environment from the web socket string
 #[derive(Debug)]
-#[cfg(not(debug_assertions))]
 enum Environment {
     Dev,
     Staging,
@@ -23,15 +8,13 @@ enum Environment {
 }
 
 // The web socket addresses for the different environments
-#[cfg(not(debug_assertions))]
 mod web_socket_urls {
-    pub const DEV: &str = "wss://dev.orchestrator.nexus.xyz:443/";
-    pub const STAGING: &str = "wss://staging.orchestrator.nexus.xyz:443/";
-    pub const BETA: &str = "wss://beta.orchestrator.nexus.xyz:443/";
+    pub const DEV: &str = "wss://dev.orchestrator.nexus.xyz:443/prove";
+    pub const STAGING: &str = "wss://staging.orchestrator.nexus.xyz:443/prove";
+    pub const BETA: &str = "wss://beta.orchestrator.nexus.xyz:443/prove";
 }
 
 // the firebase APP IDS by environment
-#[cfg(not(debug_assertions))]
 mod firebase {
     pub const DEV_APP_ID: &str = "1:954530464230:web:f0a14de14ef7bcdaa99627";
     pub const STAGING_APP_ID: &str = "1:222794630996:web:1758d64a85eba687eaaac1";
@@ -46,7 +29,6 @@ mod firebase {
 }
 
 // Release versions (existing code)
-#[cfg(not(debug_assertions))]
 pub fn analytics_id(ws_addr_string: &str) -> String {
     // Determine the environment from the web socket string (ws_addr_string)
     let env = match ws_addr_string {
@@ -65,7 +47,6 @@ pub fn analytics_id(ws_addr_string: &str) -> String {
     }
 }
 
-#[cfg(not(debug_assertions))]
 pub fn analytics_api_key(ws_addr_string: &str) -> String {
     match ws_addr_string {
         web_socket_urls::DEV => firebase::DEV_API_SECRET.to_string(),


### PR DESCRIPTION
the CLI was not properly sending analytics event.

There were two issues:
1. depending on the websocket string a different firebase key is used, this had the wrong key <--- main issue
2. `analytics_api_key`function returned empty string in debug mode <--- minor issue