### PR TITLE
Add protoc to prerequisites in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ If you don't have Rust installed, you will be prompted to install it.
 ### Linux
 ```bash
 sudo apt update && sudo apt upgrade
-sudo apt install build-essential pkg-config libssl-dev git-all
+sudo apt install build-essential pkg-config libssl-dev git-all protobuf-compiler
 ```
 
 ### macOS


### PR DESCRIPTION
**This PR** updates the **README.md** file to include the `protoc` (Protocol Buffers compiler) package as a prerequisite for Linux systems. The addition ensures that users do not encounter build errors related to missing protoc during the Nexus CLI installation process.

**Changes Made**:

Added `protobuf-compiler` to the apt install command under the Linux prerequisites section.
Why This Change is Needed:

The installation process for the Nexus CLI depends on protoc for building components.
Without this dependency, users may encounter errors like `Failed to run protoc: No such file or directory.`