### PR TITLE
Move mkdir to top of install.sh

### DIFF
--- a/public/install.sh
+++ b/public/install.sh
@@ -6,6 +6,8 @@ GREEN='\033[1;32m'
 ORANGE='\033[1;33m'
 NC='\033[0m' # No Color
 
+[ -d $NEXUS_HOME ] || mkdir -p $NEXUS_HOME
+
 while [ -z "$NONINTERACTIVE" ] && [ ! -f "$NEXUS_HOME/prover-id" ]; do
     read -p "Do you agree to the Nexus Beta Terms of Use (https://nexus.xyz/terms-of-use)? (Y/n) " yn </dev/tty
     case $yn in
@@ -51,7 +53,6 @@ if [ -d "$REPO_PATH" ]; then
   echo "$REPO_PATH exists. Updating.";
   (cd $REPO_PATH && git stash save && git fetch --tags)
 else
-  mkdir -p $NEXUS_HOME
   (cd $NEXUS_HOME && git clone https://github.com/nexus-xyz/network-api)
 fi
 (cd $REPO_PATH && git -c advice.detachedHead=false checkout $(git rev-list --tags --max-count=1))


### PR DESCRIPTION
move mkdir to top, so it can save the prover id

to prevent creation of new prover-id
sh: 39: cannot create /home/username/.nexus/prover-id: Directory nonexistent

Warning: Could not read prover-id file: No such file or directory (os error 2)
Successfully saved new prover-id to file: favored-plantocracies-92
