### PR TITLE
docs: typo fix Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,7 @@ If you have examples of other tools that have the feature you are requesting, pl
 Pull requests are the way concrete changes are made to the code, documentation, and dependencies of the Nexus network.
 
 Before making a large change, it is usually a good idea to first open an issue describing the change to solicit feedback and guidance. 
-This will increase the likelihood of the PR getting merged. Striking up a discussion the [Discord][discord] to let the community know
+This will increase the likelihood of the PR getting merged. Striking up a discussion on the [Discord][discord] to let the community know
 what you'll be working on can also be helpful for getting early feedback before diving in.
 
 If you are working on a larger feature, we encourage you to open up a draft pull request and also check in with the [Discord][discord], to make sure that other


### PR DESCRIPTION
This update fixes a minor grammatical oversight in the contributing guide. The sentence:  

> Striking up a discussion the [Discord][discord] to let the community know what you'll be working on...  

has been corrected to:  

> Striking up a discussion on the [Discord][discord] to let the community know what you'll be working on...  

The addition of the preposition "on" ensures proper grammar and enhances the readability of the guide. 