### PR TITLE
feat: protoc should not be required

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,6 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Install protoc
-        uses: arduino/setup-protoc@v3
-
       - name: Set up Rust cache
         uses: Swatinem/rust-cache@v2
         with:

--- a/clients/cli/Cargo.lock
+++ b/clients/cli/Cargo.lock
@@ -927,12 +927,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fixedbitset"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1576,12 +1570,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "multimap"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
-
-[[package]]
 name = "native-tls"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1665,10 +1653,10 @@ dependencies = [
  "iana-time-zone",
  "jsonrpsee",
  "md5",
+ "native-tls",
  "nexus-core",
  "parking_lot",
  "prost",
- "prost-build",
  "rand 0.8.5",
  "random_word",
  "reqwest",
@@ -1935,16 +1923,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
-name = "petgraph"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
-dependencies = [
- "fixedbitset",
- "indexmap",
-]
-
-[[package]]
 name = "pin-project"
 version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1995,16 +1973,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
-name = "prettyplease"
-version = "0.2.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
-dependencies = [
- "proc-macro2",
- "syn 2.0.71",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2024,27 +1992,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prost-build"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb182580f71dd070f88d01ce3de9f4da5021db7115d2e1c3605a754153b77c1"
-dependencies = [
- "bytes",
- "heck",
- "itertools 0.12.1",
- "log",
- "multimap",
- "once_cell",
- "petgraph",
- "prettyplease",
- "prost",
- "prost-types",
- "regex",
- "syn 2.0.71",
- "tempfile",
-]
-
-[[package]]
 name = "prost-derive"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2055,15 +2002,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.71",
-]
-
-[[package]]
-name = "prost-types"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cee5168b05f49d4b0ca581206eb14a7b22fafd963efe729ac48eb03266e25cc2"
-dependencies = [
- "prost",
 ]
 
 [[package]]

--- a/clients/cli/Cargo.lock
+++ b/clients/cli/Cargo.lock
@@ -1624,7 +1624,7 @@ dependencies = [
 
 [[package]]
 name = "nexus-network"
-version = "0.4.0"
+version = "0.4.3"
 dependencies = [
  "ark-bn254",
  "ark-crypto-primitives",

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nexus-network"
-version = "0.4.0"
+version = "0.4.3"
 edition = "2021"
 
 [[bin]]

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -7,9 +7,6 @@ edition = "2021"
 name = "prover"
 path = "src/prover.rs"
 
-[build-dependencies]
-prost-build = "0.13"
-
 [profile.dev]
 opt-level = 1
 

--- a/clients/cli/build.rs
+++ b/clients/cli/build.rs
@@ -1,29 +1,16 @@
-use std::{error::Error, path::PathBuf, process::Command};
+use std::{error::Error, path::PathBuf};
 
 fn main() -> Result<(), Box<dyn Error>> {
-    let out_dir: PathBuf = "./src/generated/".into();
-    let proto_file: PathBuf = "../../proto/orchestrator.proto".into();
-    let proto_dir = match proto_file.parent().ok_or("Failed to get parent directory of proto file") {
-        Ok(dir) => dir,
-        Err(e) => return Err(e.into()),
-    };
+    let generated_file: PathBuf = "./src/generated/nexus.orchestrator.rs".into();
 
-    match Command::new("protoc")
-        .arg("--version")
-        .output() { 
-        Ok(_) => prost_build::Config::new()
-            .out_dir(out_dir)
-            .protoc_arg("--experimental_allow_proto3_optional")
-            .compile_protos(&[&proto_file], &[proto_dir])?,
-        Err(e) => {
-            // Skipping protobuf compilation.
-            println!("cargo:warning=Failed to run protoc: {}", e);
-            return Err(e.into());
-        }
+    // Verify the generated file exists
+    if !generated_file.exists() {
+        println!(
+            "cargo:warning=Generated protobuf file not found at {}",
+            generated_file.display()
+        );
+        return Err("Missing required generated protobuf file".into());
     }
-
-     // Tell Cargo to rerun this script if the proto file changes
-     println!("cargo:rerun-if-changed={}", proto_file.display());
 
     Ok(())
 }


### PR DESCRIPTION
This PR addresses: [https://github.com/nexus-xyz/network-api/issues/55](https://github.com/nexus-xyz/network-api/issues/55).

## Current state of the world (before this PR)

The CLI requires `protoc` to be installed in user's computer to run. However, the protobuf files are already in the repo, so this is actually unnecessary.

## What this PR does

### Main Intent
1. Updates `build.rs` so it checks for the  previously generated protobuf files... so it does not block on if `protoc` is missing.
2. Updates the CI file so it does not install protoc
3. Updates the `cargo.toml` so it does not use prost-build (which requires protoc be installed)

### Secondary Intent
1. Bumps the version number

## How I tested this PR

1. I removed `protoc` from my computer
2. I tested so that:

```sh
$ protoc --version
> zsh: command not found: protoc
```

3. I ran the `cargo run` to make sure that the app still built and ran <-- this passes as expected

```sh
# to clean the local builds
$ cargo clean

# build to see proving
$ cargo run --release ...
```

5. I ran the `install.sh` to make sure that the app still built and ran <--- this is currently NOT working because it does a fresh install from github (not the code in this PR).