### PR TITLE
fix Update test_updater.sh

### DIFF
--- a/tests/test_updater.sh
+++ b/tests/test_updater.sh
@@ -106,7 +106,7 @@ ORIGINAL_PID=$!
 echo -e "${ORANGE}[test-updater script] (7 / 18) Original PID for the CLI main process: $ORIGINAL_PID${NC}"
 echo " "
 
-# Give CLI some timee to start the proving by starting the main thread at prover.rs
+# Give CLI some time to start the proving by starting the main thread at prover.rs
 sleep 30 
 
 # Create new version with higher number than 0.3.5


### PR DESCRIPTION
The word "timee" contains a typo. The correct spelling is "**time**".