### PR TITLE
fix: Update deprecated git stash save to git stash for compatibility

### DIFF
--- a/public/install.sh
+++ b/public/install.sh
@@ -41,7 +41,7 @@ fi
 REPO_PATH=$NEXUS_HOME/network-api
 if [ -d "$REPO_PATH" ]; then
   echo "$REPO_PATH exists. Updating.";
-  (cd $REPO_PATH && git stash save && git fetch --tags)
+  (cd $REPO_PATH && git stash && git fetch --tags)
 else
   (cd $NEXUS_HOME && git clone https://github.com/nexus-xyz/network-api)
 fi


### PR DESCRIPTION
### Description
This change addresses a compatibility issue in the installation script. The command:  

```sh
(cd $REPO_PATH && git stash save && git fetch --tags)
```  

was using `git stash save`, which is deprecated in modern versions of Git. To ensure compatibility and avoid potential errors, this has been updated to:  

```sh
(cd $REPO_PATH && git stash && git fetch --tags)
```  

## Why this matters
- The `git stash save` command has been replaced by `git stash push` in recent versions of Git, and `git stash` alone is sufficient for typical use cases.
- The updated script now works seamlessly across all Git versions without errors.  

This change improves reliability and ensures smoother installation for users with updated Git versions.