### PR TITLE
Fix spelling and grammar issues

### DIFF
--- a/clients/cli/src/prover.rs
+++ b/clients/cli/src/prover.rs
@@ -238,7 +238,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
                 // Send ping to the websocket connection and wait for pong
                 match client.send(Message::Ping(vec![])).await {
-                    //The ping was succesfully sent...
+                    //The ping was successfully sent...
                     Ok(_) => {
                         //...wait for pong response from websocket with timeout...
                         match tokio::time::timeout(std::time::Duration::from_secs(5), client.next())
@@ -249,7 +249,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 // Connection is verified working
                                 match client.send(Message::Binary(progress.encode_to_vec())).await {
                                     Ok(_) => {
-                                        // println!("\t\tSuccesfully sent progress to orchestrator\n");
+                                        // println!("\t\tSuccessfully sent progress to orchestrator\n");
                                         // println!("{:#?}", progress);
 
                                         // Reset the queued values only after successful send

--- a/proto/orchestrator.proto
+++ b/proto/orchestrator.proto
@@ -44,7 +44,7 @@ enum Network {
   // Experimental new network types should leave the network unspecified.
   NETWORK_UNSPECIFIED = 0;
 
-  // A open "playground" for those looking to experience the Nexus protocol
+  // An open "playground" for those looking to experience the Nexus protocol
   // as a proof requestor, prover, app developer, or validator.
   NETWORK_DEVNET = 1;
 


### PR DESCRIPTION


Changes:
1. clients/cli/src/prover.rs:
- "succesfully" -> "successfully"

2. proto/orchestrator.proto:
- "A open" -> "An open"

Reason:
Fixed spelling of "successfully" and corrected grammar article usage before vowel sound ("an" before "open").

Impact:
Documentation-only changes, no code functionality affected.