### PR TITLE
Fix protobuf compilation error by enabling proto3 optional

### DIFF
--- a/clients/cli/build.rs
+++ b/clients/cli/build.rs
@@ -53,6 +53,9 @@ fn main() -> Result<(), Box<dyn Error>> {
         println!("Created output directory {}.", out_dir);
     }
 
+    // Allow proto3 experimental
+    config.protoc_arg("--experimental_allow_proto3_optional");
+    
     // Attempt to compile the .proto file
     match config.compile_protos(&["proto/orchestrator.proto"], &["proto"]) {
         Ok(_) => {

--- a/clients/cli/src/setup.rs
+++ b/clients/cli/src/setup.rs
@@ -85,11 +85,15 @@ pub async fn run_initial_setup() -> SetupResult {
         );
 
         //ask the user if they want to use the existing config
-        println!("Do you want to use the existing user account? (y/n)");
-        let mut use_existing_config = String::new();
+        println!("Do you want to use the existing user account? (y/n) y");
+        let mut use_existing_config = "y" // String::new();
+
+        /*
         std::io::stdin()
             .read_line(&mut use_existing_config)
             .unwrap();
+        */
+            
         let use_existing_config = use_existing_config.trim();
         if use_existing_config == "y" {
             match fs::read_to_string(&node_id_path) {

--- a/clients/cli/src/setup.rs
+++ b/clients/cli/src/setup.rs
@@ -86,7 +86,7 @@ pub async fn run_initial_setup() -> SetupResult {
 
         //ask the user if they want to use the existing config
         println!("Do you want to use the existing user account? (y/n) y");
-        let mut use_existing_config = "y" // String::new();
+        let mut use_existing_config = "y"; // String::new();
 
         /*
         std::io::stdin()


### PR DESCRIPTION
Compilation error due missing optional field `--experimental_allow_proto3_optional`

```
Error compiling protobuf files: protoc failed: orchestrator.proto: This file contains proto3 optional fields, but --experimental_allow_proto3_optional was not set.
```