### PR TITLE
Enabling proto3_optional flag

### DIFF
--- a/clients/cli/build.rs
+++ b/clients/cli/build.rs
@@ -10,6 +10,8 @@ fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo:rerun-if-changed=build.rs");
 
     let mut config = Config::new();
+    config.protoc_arg("--experimental_allow_proto3_optional");
+
 
     // Print current directory
     println!("Current dir: {:?}", env::current_dir()?);


### PR DESCRIPTION
This PR fixes the Protobuf compilation issue where protoc fails due to proto3 optional fields not being explicitly allowed. 
Error message was :` Error compiling protobuf files: protoc failed: orchestrator.proto: This file contains proto3 optional fields, but --experimental_allow_proto3_optional was not set.` 


**Changes Made:**

1. Updated the build.rs file to add config.protoc_arg("--experimental_allow_proto3_optional");
2. Ensured that the correct .proto files are compiled without errors.
3. Verified that protoc runs successfully and generates the required Rust files.

**Why This Fix?**

1. Newer .proto files use optional fields in proto3, which require the --experimental_allow_proto3_optional flag to be set explicitly.
2. Without this fix, developers cloning the repo and trying to build the project would face errors.
 
 
 