### PR TITLE
fix: fix missing pull/rebase after stash in network-api update

### DIFF
--- a/public/install.sh
+++ b/public/install.sh
@@ -73,6 +73,7 @@ if [ -d "$REPO_PATH" ]; then
   (
     cd "$REPO_PATH" || exit
     git stash
+    git pull --rebase
     git fetch --tags
   )
 else


### PR DESCRIPTION
Noticed that in section (6) *Clone or update the network-api repository*, the script runs `git stash` but doesn’t follow up with `git pull` or `git rebase`, leaving the local copy outdated.
Added the missing step to ensure the repository actually updates.