### PR TITLE
Fixing Documentation Comment and Formatting Issues

### DIFF
--- a/clients/cli/src/utils/updater.rs
+++ b/clients/cli/src/utils/updater.rs
@@ -74,7 +74,7 @@ pub enum VersionStatus {
     UpToDate,
 }
 
-// Struct to manage the version of the CLI it is running at all times
+/// Struct to manage the version of the CLI it is running at all times
 // This is also used to check for updates and apply them
 pub struct VersionManager {
     current_version: Arc<RwLock<Version>>,

--- a/public/install.sh
+++ b/public/install.sh
@@ -104,6 +104,5 @@ fi
 # and uncomment the line below.
 #
 # echo "Current location: $(pwd)"
-# (cd clients/cli &&   cargo run -r -- start --env beta
-# )
+# (cd clients/cli &&   cargo run -r -- start --env beta)
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Reason: Rustdoc uses /// for documentation comments that should be included in API documentation. The incorrect use of // prevented proper documentation parsing.

Reason: The closing parenthesis should be on the same line to maintain the correct structure, even within a commented-out section.