### PR TITLE
Update README.md to include Protobuf compiler update instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,11 +108,14 @@ sudo apt install build-essential pkg-config libssl-dev git-all protobuf-compiler
 For Proto3 syntax compatibility and to avoid common issues with older versions, you must update your Protobuf compiler. Follow these steps:
 ```bash
 sudo apt remove -y protobuf-compiler
-sudo curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protoc-21.12-linux-x86_64.zip
+
+# Visit the Protobuf GitHub releases page to download the latest version suitable for your system:
+# https://github.com/protocolbuffers/protobuf/releases
+# After downloading, unzip the package and install:
 sudo apt install unzip
-sudo unzip protoc-21.12-linux-x86_64.zip -d /usr/local
+sudo unzip protoc-*-linux-x86_64.zip -d /usr/local
 sudo chmod +x /usr/local/bin/protoc
-rm protoc-21.12-linux-x86_64.zip
+rm protoc-*-linux-x86_64.zip
 
 ### macOS
 

--- a/README.md
+++ b/README.md
@@ -104,14 +104,18 @@ If you don’t have Rust installed, you will be prompted to install it (unless `
 sudo apt update && sudo apt upgrade
 sudo apt install build-essential pkg-config libssl-dev git-all protobuf-compiler
 ```
-#### Update Protobuf Compiler
-For Proto3 syntax compatibility and to avoid common issues with older versions, you must update your Protobuf compiler. Follow these steps:
+### Update Protobuf Compiler
+
+To ensure compatibility with Proto3 syntax, update your Protobuf compiler by following these steps:
+
 ```bash
+# Remove the old protobuf-compiler if installed
 sudo apt remove -y protobuf-compiler
 
 # Visit the Protobuf GitHub releases page to download the latest version suitable for your system:
-# https://github.com/protocolbuffers/protobuf/releases
-# After downloading, unzip the package and install:
+# Link: https://github.com/protocolbuffers/protobuf/releases
+# Download the protoc binary suitable for your system and unzip if necessary
+
 sudo apt install unzip
 sudo unzip protoc-*-linux-x86_64.zip -d /usr/local
 sudo chmod +x /usr/local/bin/protoc

--- a/README.md
+++ b/README.md
@@ -104,6 +104,15 @@ If you don’t have Rust installed, you will be prompted to install it (unless `
 sudo apt update && sudo apt upgrade
 sudo apt install build-essential pkg-config libssl-dev git-all protobuf-compiler
 ```
+#### Update Protobuf Compiler
+For Proto3 syntax compatibility and to avoid common issues with older versions, you must update your Protobuf compiler. Follow these steps:
+```bash
+sudo apt remove -y protobuf-compiler
+sudo curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protoc-21.12-linux-x86_64.zip
+sudo apt install unzip
+sudo unzip protoc-21.12-linux-x86_64.zip -d /usr/local
+sudo chmod +x /usr/local/bin/protoc
+rm protoc-21.12-linux-x86_64.zip
 
 ### macOS
 


### PR DESCRIPTION
Added detailed steps to update the Protobuf compiler to the latest version under the Linux prerequisites section. This update ensures compatibility with Proto3 syntax and resolves common issues with outdated Protobuf versions, enhancing the setup experience for new users.

close https://github.com/nexus-xyz/network-api/issues/1413