### PR TITLE
chore!: Update API version

### DIFF
--- a/clients/cli/Cargo.lock
+++ b/clients/cli/Cargo.lock
@@ -1610,7 +1610,7 @@ dependencies = [
 
 [[package]]
 name = "nexus-network"
-version = "0.5.8"
+version = "0.6.0"
 dependencies = [
  "async-stream",
  "blake3",

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nexus-network"
-version = "0.5.8"
+version = "0.6.0"
 edition = "2021"
 rust-version = "1.75"
 build = "build.rs"

--- a/clients/cli/src/config.rs
+++ b/clients/cli/src/config.rs
@@ -10,10 +10,10 @@ pub enum Environment {
 impl Environment {
     pub fn orchestrator_url(&self) -> String {
         match self {
-            Environment::Local => "http://localhost:8080".to_string(),
-            Environment::Dev => "https://dev.orchestrator.nexus.xyz".to_string(),
-            Environment::Staging => "https://staging.orchestrator.nexus.xyz".to_string(),
-            Environment::Beta => "https://beta.orchestrator.nexus.xyz".to_string(),
+            Environment::Local => "http://localhost:8080/v2/".to_string(),
+            Environment::Dev => "https://dev.orchestrator.nexus.xyz/v2/".to_string(),
+            Environment::Staging => "https://staging.orchestrator.nexus.xyz/v2/".to_string(),
+            Environment::Beta => "https://beta.orchestrator.nexus.xyz/v2/".to_string(),
         }
     }
 

--- a/clients/cli/src/config.rs
+++ b/clients/cli/src/config.rs
@@ -10,10 +10,10 @@ pub enum Environment {
 impl Environment {
     pub fn orchestrator_url(&self) -> String {
         match self {
-            Environment::Local => "http://localhost:8080/v2/".to_string(),
-            Environment::Dev => "https://dev.orchestrator.nexus.xyz/v2/".to_string(),
-            Environment::Staging => "https://staging.orchestrator.nexus.xyz/v2/".to_string(),
-            Environment::Beta => "https://beta.orchestrator.nexus.xyz/v2/".to_string(),
+            Environment::Local => "http://localhost:8080".to_string(),
+            Environment::Dev => "https://dev.orchestrator.nexus.xyz".to_string(),
+            Environment::Staging => "https://staging.orchestrator.nexus.xyz".to_string(),
+            Environment::Beta => "https://beta.orchestrator.nexus.xyz".to_string(),
         }
     }
 

--- a/clients/cli/src/orchestrator_client.rs
+++ b/clients/cli/src/orchestrator_client.rs
@@ -37,7 +37,7 @@ impl OrchestratorClient {
         U: Message + Default,
     {
         let request_bytes = request_data.encode_to_vec();
-        let url = format!("{}{}", self.base_url, url);
+        let url = format!("{}/v2{}", self.base_url, url);
 
         let friendly_connection_error =
             "[CONNECTION] Unable to reach server. The service might be temporarily unavailable."

--- a/clients/cli/src/utils/cli_branding.rs
+++ b/clients/cli/src/utils/cli_branding.rs
@@ -53,7 +53,7 @@ pub fn print_banner() {
         "{} {} {}\n",
         "Welcome to the".bright_white(),
         "Nexus Network CLI".bright_cyan().bold(),
-        "v0.5.8".bright_white()
+        "v0.6.0".bright_white()
     );
     println!(
         "{}",


### PR DESCRIPTION
Orchestrator API path is changing, so update version number and path to match.

Clients that encounter 4xx errors will need to update.