### PR TITLE
fix: logging, default to authenticated proving, automatic version

### DIFF
--- a/clients/cli/Cargo.lock
+++ b/clients/cli/Cargo.lock
@@ -827,6 +827,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcaee3d8e3cfc3fd92428d477bc97fc29ec8716d180c0d74c643bb26166660e0"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "humantime",
+ "log",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1211,6 +1234,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
 name = "hyper"
 version = "0.14.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1499,9 +1528,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
 
 [[package]]
 name = "matchers"
@@ -1610,7 +1639,7 @@ dependencies = [
 
 [[package]]
 name = "nexus-network"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "async-stream",
  "blake3",
@@ -1619,9 +1648,11 @@ dependencies = [
  "colored",
  "directories",
  "dirs",
+ "env_logger",
  "futures",
  "home",
  "iana-time-zone",
+ "log",
  "md5",
  "native-tls",
  "nexus-common",

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nexus-network"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 rust-version = "1.75"
 build = "build.rs"

--- a/clients/cli/src/prover.rs
+++ b/clients/cli/src/prover.rs
@@ -31,7 +31,7 @@ async fn authenticated_proving(
         },
     };
 
-    let public_input: u32 = proof_task.public_inputs.get(0).cloned().unwrap_or_default() as u32;
+    let public_input: u32 = proof_task.public_inputs.first().cloned().unwrap_or_default() as u32;
 
     println!("Compiling guest program...");
     let elf_file_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -79,7 +79,7 @@ async fn authenticated_proving(
         .submit_proof(node_id, &proof_hash, proof_bytes)
         .await{
             error!("Failed to submit proof: {}", e);
-            return Err(e.into());
+            return Err(e);
         }
     
     println!("{}", "ZK proof successfully submitted".green());

--- a/clients/cli/src/prover.rs
+++ b/clients/cli/src/prover.rs
@@ -8,7 +8,7 @@ use crate::setup;
 use crate::utils;
 use colored::Colorize;
 use sha3::{Digest, Keccak256};
-use log::{error, info, warn};
+use log::{error, warn};
 use std::time::Duration;
 
 /// Proves a program with a given node ID

--- a/clients/cli/src/prover.rs
+++ b/clients/cli/src/prover.rs
@@ -23,7 +23,6 @@ async fn authenticated_proving(
     let proof_task = match client.get_proof_task(node_id).await {
         Ok(task) => {
             println!("Successfully fetched task from Nexus Orchestrator.");
-            println!("Success.");
             task
         },
         Err(_) => {

--- a/clients/cli/src/setup.rs
+++ b/clients/cli/src/setup.rs
@@ -86,13 +86,13 @@ pub async fn run_initial_setup() -> SetupResult {
         );
 
         //ask the user if they want to use the existing config
-        println!("Do you want to use the existing user account? (y/n)");
+        println!("Do you want to use the existing user account? [Y/n]");
         let mut use_existing_config = String::new();
         std::io::stdin()
             .read_line(&mut use_existing_config)
             .unwrap();
         let use_existing_config = use_existing_config.trim();
-        if use_existing_config == "y" {
+        if use_existing_config != "n" {
             match fs::read_to_string(&node_id_path) {
                 Ok(content) => {
                     return SetupResult::Connected(content.trim().to_string());

--- a/clients/cli/src/utils/cli_branding.rs
+++ b/clients/cli/src/utils/cli_branding.rs
@@ -49,11 +49,15 @@ pub const LOGO_NAME: &str = r#"
 
 pub fn print_banner() {
     println!("{}", LOGO_NAME.bright_cyan());
+    let version = match option_env!("CARGO_PKG_VERSION") {
+        Some(v) => format!("v{}", v),
+        None => "(unknown version)".into(),
+    };
     println!(
         "{} {} {}\n",
         "Welcome to the".bright_white(),
         "Nexus Network CLI".bright_cyan().bold(),
-        "v0.6.0".bright_white()
+        version.bright_white()
     );
     println!(
         "{}",


### PR DESCRIPTION
- Detect version automatically.
- Default to using the node id.
- Ensure that proving log statements are visible by default. (They were info-level. If we default to info-level, we could change this back.)

![Screenshot 2025-02-27 at 12 17 27 PM](https://github.com/user-attachments/assets/401cbffe-4789-497e-b843-4128f518e9ea)
