### PR TITLE
Increased client timeout

### DIFF
--- a/clients/cli/src/orchestrator_client.rs
+++ b/clients/cli/src/orchestrator_client.rs
@@ -18,7 +18,7 @@ impl OrchestratorClient {
     pub fn new(environment: config::Environment) -> Self {
         Self {
             client: ClientBuilder::new()
-                .timeout(Duration::from_millis(1000))
+                .timeout(Duration::from_secs(10))
                 .build()
                 .expect("Failed to create HTTP client"),
             base_url: environment.orchestrator_url(),


### PR DESCRIPTION
### Description
Submit requests are typically processed in approximately 1 second. Based on the obtained data and conducted tests, the time is typically greater than the configured client timeout. Increasing the timeout will significantly improve the success rate of submits.