### PR TITLE
feat: don’t require protoc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,11 +85,10 @@ tag in the commits.
 
 #### Proto Compilation
 
-By default, the build process skips proto compilation to make it easier for contributors to work on the codebase without needing protobuf tooling. If you need to modify or regenerate the proto files, you can enable proto compilation by setting the `BUILD_PROTO` environment variable:
+By default, the build process skips proto compilation to make it easier for contributors to work on the codebase without needing protobuf tooling. If you need to modify or regenerate the proto files, you can enable proto compilation by using the `build_proto` flag:
 
 ```bash
-export BUILD_PROTO=1
-cargo build
+cargo build --build_proto
 ```
 
 <sub><sup>_Adapted from the [Reth contributing guide][reth-contributing]_.</sub></sup>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,10 +85,10 @@ tag in the commits.
 
 #### Proto Compilation
 
-By default, the build process skips proto compilation to make it easier for contributors to work on the codebase without needing protobuf tooling. If you need to modify or regenerate the proto files, you can enable proto compilation by using the `build_proto` flag:
+By default, the build process skips proto compilation to make it easier for contributors to work on the codebase without needing protobuf tooling. If you need to modify or regenerate the proto files, you can enable proto compilation by using the `build_proto` feature:
 
 ```bash
-cargo build --build_proto
+cargo build --features build_proto
 ```
 
 <sub><sup>_Adapted from the [Reth contributing guide][reth-contributing]_.</sub></sup>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,6 +83,15 @@ remaining). When doing so, it is courteous to give the original contributor cred
 preserving their name and e-mail address in the commit log, or by using the `Author: ` or `Co-authored-by: ` metadata
 tag in the commits.
 
+#### Proto Compilation
+
+By default, the build process skips proto compilation to make it easier for contributors to work on the codebase without needing protobuf tooling. If you need to modify or regenerate the proto files, you can enable proto compilation by setting the `BUILD_PROTO` environment variable:
+
+```bash
+export BUILD_PROTO=1
+cargo build
+```
+
 <sub><sup>_Adapted from the [Reth contributing guide][reth-contributing]_.</sub></sup>
 
 [rust-coc]: https://github.com/rust-lang/rust/blob/master/CODE_OF_CONDUCT.md

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 rust-version = "1.75"
 build = "build.rs"
 
+[features]
+build_proto = []
+
 [workspace]
 members = [
     "examples",

--- a/clients/cli/build.rs
+++ b/clients/cli/build.rs
@@ -44,8 +44,8 @@ fn main() -> Result<(), Box<dyn Error>> {
     if output.status.success() {
         println!("protoc is installed and accessible.");
     } else {
-        println!("Error: protoc is not installed or not in PATH.");
-        return Err("protoc not found".into());
+        println!("protoc is not installed - using precompiled proto.");
+        return Ok(());
     }
 
     // Check if the output directory exists and is writable

--- a/clients/cli/build.rs
+++ b/clients/cli/build.rs
@@ -5,9 +5,9 @@ use std::process::Command;
 use std::{env, path::Path};
 
 fn main() -> Result<(), Box<dyn Error>> {
-    // Skip proto compilation unless build_proto flag is enabled
-    if !cfg!(flag = "build_proto") {
-        println!("Skipping proto compilation (enable with --build_proto)");
+    // Skip proto compilation unless build_proto feature is enabled
+    if !cfg!(feature = "build_proto") {
+        println!("Skipping proto compilation (enable with --features build_proto)");
         return Ok(());
     }
 

--- a/clients/cli/build.rs
+++ b/clients/cli/build.rs
@@ -5,9 +5,9 @@ use std::process::Command;
 use std::{env, path::Path};
 
 fn main() -> Result<(), Box<dyn Error>> {
-    // Skip proto compilation if BUILD_PROTO is not set to 1
-    if env::var("BUILD_PROTO").unwrap_or_default() != "1" {
-        println!("Skipping proto compilation (set BUILD_PROTO=1 to enable)");
+    // Skip proto compilation unless build_proto flag is enabled
+    if !cfg!(flag = "build_proto") {
+        println!("Skipping proto compilation (enable with --build_proto)");
         return Ok(());
     }
 


### PR DESCRIPTION
- Update build.rs to skip compilation unless `--features build_proto` is set.
- Update docs