### PR TITLE
docs: fix README “Open an issue” link

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ following format:
 
 - [Network FAQ](https://docs.nexus.xyz/layer-1/network-devnet/faq)
 - [Discord Community](https://discord.gg/nexus-xyz)
-- Technical issues? [Open an issue](https://github.com/nexus-xyz/network-cli/issues)
+- Technical issues? [Open an issue](https://github.com/nexus-xyz/nexus-cli/issues)
 
 ---
 


### PR DESCRIPTION
The **Get Help -> Open an issue** link pointed to the `network-api` repository.
It now points to `nexus-cli`, ensuring users file issues in the correct tracker.






