### PR TITLE
fix: The install script should match the binary only, not the sha256 digest

### DIFF
--- a/public/install.sh
+++ b/public/install.sh
@@ -127,7 +127,8 @@ esac
 
 # Get the latest release URL
 LATEST_RELEASE_URL=$(curl -s https://api.github.com/repos/nexus-xyz/nexus-cli/releases/latest |
-    grep "browser_download_url.*$BINARY_NAME" |
+    grep "browser_download_url" |
+    grep "$BINARY_NAME\"" |       # Match exact file name (not .sha256)
     cut -d '"' -f 4)
 
 if [ -z "$LATEST_RELEASE_URL" ]; then


### PR DESCRIPTION
Currently, the install script greps for the latest release artifact for the given platform. The grep matches both the binary and the sha256 digest, causing the install script to fail to download the binary.

Updates the grep to exactly match the expected binary filename.

Fixes: https://linear.app/nexus-labs/issue/NET-1291/cli-install-script-does-not-install-to-nexusbin