### PR TITLE
fix dead FAQ link in CLI README

### DIFF
--- a/clients/cli/README.md
+++ b/clients/cli/README.md
@@ -76,7 +76,7 @@ The Nexus CLI requires at least 4 GB of RAM. If multithreading is enabled, allot
 
 ## 📚 Resources
 
-* [Network FAQ](https://nexus.xyz/network#network-faqs)
+* [Network FAQ](https://docs.nexus.xyz/layer-1/network-devnet/faq)
 * [Discord server](https://discord.gg/nexus-xyz)
 
 ## 🛠 Developer Requirements


### PR DESCRIPTION
Updated the broken link to Nexus Network FAQs (404) with the correct working URL that points to the official documentation FAQ page.