### PR TITLE
docs: improve terminology consistency in README.md

### DIFF
--- a/clients/cli/README.md
+++ b/clients/cli/README.md
@@ -69,7 +69,6 @@ The Nexus CLI requires at least 4 GB of RAM. If multithreading is enabled, allot
 ## ⚠️ Known issues
 
 * Only the latest version of the CLI is currently supported.
-* Linking email to prover ID is currently available on the web version only.
 * Tracking of proved cycles is not yet available in the CLI.
 * Only proving is supported. Submitting programs to the network is in private beta.
   To request an API key, contact us at growth@nexus.xyz.


### PR DESCRIPTION
I noticed a couple of small inconsistencies while reading the documentation:

1. Changed "prover id" to "prover ID" to match how ID is typically written elsewhere
2. Updated "Counting cycles proved" to "Tracking of proved cycles" which feels clearer about what the feature does