### PR TITLE
ci: update docker/build-push-action from v5 to v6

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: clients/cli
           file: clients/cli/Dockerfile  # Optional. Explicitly specify the Dockerfile path


### PR DESCRIPTION
Changes Made:
Updated from docker/build-push-action@v5 to docker/build-push-action@v6

https://github.com/docker/build-push-action/releases/tag/v6.18.0

