### PR TITLE
refactor(error_classifier): combine identical HTTP status code condit…

### DIFF
--- a/clients/cli/src/error_classifier.rs
+++ b/clients/cli/src/error_classifier.rs
@@ -35,13 +35,10 @@ impl ErrorClassifier {
         match error {
             // Non-critical: Temporary server issues
             OrchestratorError::Http { status, .. } if *status == 429 => LogLevel::Debug,
-            OrchestratorError::Http { status, .. } if (500..=599).contains(status) => {
-                LogLevel::Warn
-            }
+            OrchestratorError::Http { status, .. } if (500..=599).contains(status) => LogLevel::Warn,
 
             // Critical: Auth, malformed responses
-            OrchestratorError::Http { status, .. } if *status == 401 => LogLevel::Error,
-            OrchestratorError::Http { status, .. } if *status == 403 => LogLevel::Error,
+            OrchestratorError::Http { status, .. } if *status == 401 || *status == 403 => LogLevel::Error,
 
             // Network issues - usually temporary
             _ => LogLevel::Warn,


### PR DESCRIPTION
Combine separate conditions for HTTP status codes 401 and 403 into a single condition using the logical OR operator. Both status codes return the same log level (LogLevel::Error), so this change improves code efficiency by reducing the number of checks while maintaining the same functionality