### PR TITLE
fix: correct binary name matching logic in release fetch script

### DIFF
--- a/public/install.sh
+++ b/public/install.sh
@@ -129,11 +129,11 @@ esac
 # 5) Download latest release binary
 # -----------------------------------------------------------------------------
 LATEST_RELEASE_URL=$(curl -s https://api.github.com/repos/nexus-xyz/nexus-cli/releases/latest | \
-awk -v name="$BINARY_NAME" '
+awk -v name="nexus-network-$BINARY_NAME" '
   /"name":/ {
     # Remove quotes and commas, get the value
     gsub(/[" ,]/, "", $2)
-    last_name=$2
+    last_name="nexus-network-" $2
   }
   /"browser_download_url":/ {
     gsub(/[" ,]/, "", $2)


### PR DESCRIPTION
Fixed an issue where the release fetch script incorrectly constructed the binary name using awk. The script was failing to find the correct browser_download_url because it does not appended the "nexus-network-" prefix in the beginning.

Changes:
- Fixed string concatenation logic in awk (awk requires direct string concatenation, not shell-style).
- Ensured that only the actual binary name is matched, and not incorrectly prefixed URLs.

Future suggestion: consider switching to jq for more robust and clearer JSON parsing.