### PR TITLE
Add `--no-background-color` option to CLI

### DIFF
--- a/clients/cli/src/main.rs
+++ b/clients/cli/src/main.rs
@@ -66,6 +66,10 @@ enum Command {
         /// Custom orchestrator URL (overrides environment setting)
         #[arg(long = "orchestrator-url", value_name = "URL")]
         orchestrator_url: Option<String>,
+
+        /// Disable background colors in the dashboard
+        #[arg(long = "no-background-color", action = ArgAction::SetTrue)]
+        no_background_color: bool,
     },
     /// Register a new user
     RegisterUser {
@@ -99,6 +103,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
             headless,
             max_threads,
             orchestrator_url,
+            no_background_color,
         } => {
             // If a custom orchestrator URL is provided, create a custom environment
             let final_environment = if let Some(url) = orchestrator_url {
@@ -114,6 +119,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 config_path,
                 headless,
                 max_threads,
+                no_background_color,
             )
             .await
         }
@@ -147,6 +153,7 @@ async fn start(
     config_path: std::path::PathBuf,
     headless: bool,
     max_threads: Option<u32>,
+    no_background_color: bool,
 ) -> Result<(), Box<dyn Error>> {
     let mut node_id = node_id;
     // If no node ID is provided, try to load it from the config file.
@@ -223,6 +230,7 @@ async fn start(
             orchestrator_client.environment().clone(),
             event_receiver,
             shutdown_sender,
+            no_background_color,
         );
         let res = ui::run(&mut terminal, app).await;
 

--- a/clients/cli/src/ui/dashboard.rs
+++ b/clients/cli/src/ui/dashboard.rs
@@ -43,6 +43,9 @@ pub struct DashboardState {
 
     /// The latest version string, if known.
     pub latest_version: Option<String>,
+
+    /// Whether to disable background colors
+    pub no_background_color: bool,
 }
 
 impl DashboardState {
@@ -52,11 +55,13 @@ impl DashboardState {
     /// * `node_id` - This node's unique identifier, if available.
     /// * `start_time` - The start time of the application, used for computing uptime.
     /// * `environment` - The environment in which the application is running.
+    /// * `no_background_color` - Whether to disable background colors
     pub fn new(
         node_id: Option<u64>,
         environment: Environment,
         start_time: Instant,
         events: &VecDeque<WorkerEvent>,
+        no_background_color: bool,
     ) -> Self {
         // Check for version update messages in recent events
         let (update_available, latest_version) = Self::check_for_version_updates(events);
@@ -72,6 +77,7 @@ impl DashboardState {
             events: events.clone(),
             update_available,
             latest_version,
+            no_background_color,
         }
     }
 
@@ -196,8 +202,11 @@ impl DashboardState {
 
 /// Render the dashboard screen.
 pub fn render_dashboard(f: &mut Frame, state: &DashboardState) {
-    let background_block = Block::default().style(Style::default().bg(Color::Rgb(18, 18, 24)));
-    f.render_widget(background_block, f.area());
+    // Only apply background color if no_background_color is false
+    if !state.no_background_color {
+        let background_block = Block::default().style(Style::default().bg(Color::Rgb(18, 18, 24)));
+        f.render_widget(background_block, f.area());
+    }
 
     let chunks = Layout::default()
         .direction(Direction::Vertical)

--- a/clients/cli/src/ui/mod.rs
+++ b/clients/cli/src/ui/mod.rs
@@ -51,6 +51,9 @@ pub struct App {
 
     /// Broadcasts shutdown signal to worker threads.
     shutdown_sender: broadcast::Sender<()>,
+
+    /// Whether to disable background colors
+    no_background_color: bool,
 }
 
 impl App {
@@ -60,6 +63,7 @@ impl App {
         environment: Environment,
         event_receiver: mpsc::Receiver<WorkerEvent>,
         shutdown_sender: broadcast::Sender<()>,
+        no_background_color: bool,
     ) -> Self {
         Self {
             start_time: Instant::now(),
@@ -69,6 +73,7 @@ impl App {
             events: Default::default(),
             event_receiver,
             shutdown_sender,
+            no_background_color,
         }
     }
 
@@ -81,6 +86,7 @@ impl App {
             self.environment.clone(),
             self.start_time,
             &self.events,
+            self.no_background_color,
         );
         self.current_screen = Screen::Dashboard(state);
     }
@@ -111,6 +117,7 @@ pub async fn run<B: Backend>(terminal: &mut Terminal<B>, mut app: App) -> std::i
                     app.environment.clone(),
                     app.start_time,
                     &app.events,
+                    app.no_background_color,
                 );
                 app.current_screen = Screen::Dashboard(state);
             }
@@ -125,6 +132,7 @@ pub async fn run<B: Backend>(terminal: &mut Terminal<B>, mut app: App) -> std::i
                     app.environment.clone(),
                     app.start_time,
                     &app.events,
+                    app.no_background_color,
                 ));
                 continue;
             }
@@ -154,6 +162,7 @@ pub async fn run<B: Backend>(terminal: &mut Terminal<B>, mut app: App) -> std::i
                                 app.environment.clone(),
                                 app.start_time,
                                 &app.events,
+                                app.no_background_color,
                             ));
                         }
                     }


### PR DESCRIPTION

Summary:

By default, we render the dashboard with fix background color.
In case user want to use their own terminal theme, they can specify `--no-color` to disable default background color.
