### PR TITLE
refactor: replace commented test URL with cfg-gated constant

### DIFF
--- a/clients/cli/src/version_requirements.rs
+++ b/clients/cli/src/version_requirements.rs
@@ -5,8 +5,8 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use thiserror::Error;
 
 const CONFIG_URL: &str = "https://cli.nexus.xyz/version.json";
-// For testing error messages, uncomment the line below:
-// const CONFIG_URL: &str = "https://cli.nexus.xyz/nonexistent.json";
+#[cfg(test)]
+const TEST_ERROR_URL: &str = "https://cli.nexus.xyz/nonexistent.json";
 const CONFIG_TIMEOUT: Duration = Duration::from_secs(10);
 
 #[derive(Error, Debug)]


### PR DESCRIPTION
replaces a commented-out test URL with a properly cfg-gated constant that will only be compiled in test mode

1. Removing commented code that could accidentally be uncommented during refactoring
2. Using Rust's conditional compilation feature to properly isolate test code
3. Preventing potential risk of accidentally using the test URL in production