### PR TITLE
Add Dockerfile.0.10.2, Update README.md, and Remove Old Dockerfile for nexusxyz/nexus-cli:latest to use v0.10.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,0 @@
-FROM alpine:3.22.0
-
-RUN apk update && \
-    apk add curl && \
-    curl -sSf https://cli.nexus.xyz/ -o install.sh && \
-    chmod +x install.sh && \
-    NONINTERACTIVE=1 ./install.sh
-
-ENTRYPOINT ["/root/.nexus/bin/nexus-cli"]

--- a/Dockerfile.0.10.2
+++ b/Dockerfile.0.10.2
@@ -1,0 +1,14 @@
+# Use lightweight Alpine Linux as the base image
+FROM alpine:latest
+
+# Download and install nexus-cli v0.10.2 binary
+RUN wget -O /usr/local/bin/nexus-cli \
+    https://github.com/nexus-xyz/nexus-cli/releases/download/v0.10.2/nexus-network-linux-x86_64 && \
+    chmod +x /usr/local/bin/nexus-cli
+
+# Verify SHA256 checksum for security
+RUN echo "23c369b8b1cafdb4e90b8a89cd39bca220ec1a7d1819cedfa910ce945e42a3c1  /usr/local/bin/nexus-cli" | sha256sum -c
+
+# Set default command
+ENTRYPOINT ["/usr/local/bin/nexus-cli"]
+CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -223,3 +223,24 @@ the workflow. This leads to a release without a Docker image or binaries, which 
 ## License
 
 Nexus CLI is distributed under the terms of both the [MIT License](./LICENSE-MIT) and the [Apache License (Version 2.0)](./LICENSE-APACHE).
+
+### Single Container with Dockerfile (v0.10.2)
+
+A `Dockerfile.0.10.2` is provided to build the `nexusxyz/nexus-cli:0.10.2` image, which uses the v0.10.2 binary for the Nexus Network Testnet III.
+
+#### Build the Docker Image
+```bash
+docker build -f Dockerfile.0.10.2 -t nexusxyz/nexus-cli:0.10.2 .
+```
+
+#### Pull the Latest Image
+After this PR is merged, the `latest` tag will point to v0.10.2:
+```bash
+docker pull nexusxyz/nexus-cli:latest
+```
+
+#### Verify Version
+```bash
+docker run --rm nexusxyz/nexus-cli:latest --version
+```
+Expected output: `nexus-network 0.10.2`


### PR DESCRIPTION
- Added `Dockerfile.0.10.2` to build the `nexusxyz/nexus-cli:0.10.2` image with the v0.10.2 binary and SHA256 verification.
- Updated `README.md` with complete instructions for building, pulling, and verifying the `nexus-xyz/nexus-cli:0.10.2` image.
- Removed old `Dockerfile` as it is replaced by `Dockerfile.0.10.2`.
- Currently, `docker pull nexusxyz/nexus-cli:latest` downloads v0.10.1. This PR enables updating the `latest` tag on Docker Hub to point to v0.10.2, aligning with the latest Nexus CLI release for Testnet III.
- Requesting the Nexus team to update the `latest` tag on Docker Hub to point to v0.10.2 after merging this PR.
