### PR TITLE
feat: Print task execution status when the task is completed

### DIFF
--- a/clients/cli/src/workers/authenticated_worker.rs
+++ b/clients/cli/src/workers/authenticated_worker.rs
@@ -145,6 +145,22 @@ impl AuthenticatedWorker {
             let duration_secs = start_time.elapsed().as_secs();
             self.fetcher.update_success_tracking(duration_secs);
 
+            // Send information about completing the task
+            self.event_sender
+                .send_event(Event::state_change(
+                    ProverState::Waiting,
+                    format!(
+                        "{} completed, Task size: {}, Duration: {}s, Request Difficulty: {}",
+                        task.task_id,
+                        task.public_inputs_list.len(),
+                        self.fetcher.last_success_duration_secs.unwrap_or(0),
+                        self.fetcher
+                            .last_success_difficulty
+                            .map(|difficulty| format!("{:?}", difficulty))
+                            .unwrap_or("Unknown".to_string())
+                    ),
+                ))
+                .await;
             // Check if we've reached the maximum number of tasks
             if let Some(max) = self.max_tasks {
                 if self.tasks_completed >= max {

--- a/clients/cli/src/workers/fetcher.rs
+++ b/clients/cli/src/workers/fetcher.rs
@@ -27,8 +27,8 @@ pub struct TaskFetcher {
     network_client: NetworkClient,
     event_sender: EventSender,
     config: WorkerConfig,
-    last_success_duration_secs: Option<u64>,
-    last_success_difficulty: Option<crate::nexus_orchestrator::TaskDifficulty>,
+    pub last_success_duration_secs: Option<u64>,
+    pub last_success_difficulty: Option<crate::nexus_orchestrator::TaskDifficulty>,
     last_requested_difficulty: Option<crate::nexus_orchestrator::TaskDifficulty>,
 }
 


### PR DESCRIPTION
After the task is submitted, the execution status of the task is printed so that users can understand the performance level of their own equipment and modify the task difficulty according to relevant information.

<img width="1025" height="165" alt="1757643180502_50654faa18214dafaeffaa59d13fdf84" src="https://github.com/user-attachments/assets/611f5c33-3b0c-4a57-918d-fa0976bedb71" />
