### PR TITLE
chore: release v0.10.15

### DIFF
--- a/clients/cli/Cargo.lock
+++ b/clients/cli/Cargo.lock
@@ -1621,7 +1621,7 @@ dependencies = [
 
 [[package]]
 name = "nexus-network"
-version = "0.10.14"
+version = "0.10.15"
 dependencies = [
  "assert_cmd",
  "async-trait",

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nexus-network"
-version = "0.10.14"
+version = "0.10.15"
 edition = "2024"
 rust-version = "1.85"
 build = "build.rs"


### PR DESCRIPTION
The main thing we're releasing is compiler optimization. Since it might lead to bugs, and we already had a release this week, not showing the CTA to update out of the gate, but will keep an eye on Discord to make sure it's working well.