### PR TITLE
chore: Update GitHub Action to download-artifact@v5

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -349,7 +349,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           path: artifacts
           merge-multiple: true


### PR DESCRIPTION
uses: actions/download-artifact@v4 -> uses: actions/download-artifact@v5

Version v5 introduces improved artifact handling, better caching, and reliability enhancements for multi-artifact workflows.
Release notes: https://github.com/actions/download-artifact/releases/tag/v5.0.0 