### PR TITLE
docs: update extra_large_5

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ nexus-cli start --max-difficulty extra_large_2
 nexus-cli start --max-difficulty extra_large_3
 nexus-cli start --max-difficulty extra_large_4
 
-# Equivalent to extra_large_4
+# Equivalent to extra_large_4 if no extra_large_5 tasks available
 nexus-cli start --max-difficulty extra_large_5
 
 # Case-insensitive (all equivalent)


### PR DESCRIPTION
Remove extra_large_5 task from recommended options since it is not possible to get currently
