### PR TITLE
Upgrade download-artifact action to version 6

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -349,7 +349,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v6
         with:
           path: artifacts
           merge-multiple: true


### PR DESCRIPTION
Updated the download-artifact action from v5 to v6. This version adds support for Node.js v24.x and updates the underlying dependencies.
Release notes: https://github.com/actions/download-artifact/releases/tag/v6.0.0