### PR TITLE
chore: mark old updater test script as deprecated

### DIFF
--- a/tests/test_updater.sh
+++ b/tests/test_updater.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# DEPRECATED: This test relies on the old updater logic and does not run in CI.
+# It is kept for historical reference only.
+
 # Test Auto-updater Functionality
 #
 # This script tests the CLI's auto-update mechanism by:


### PR DESCRIPTION
### What changed
The test script `tests/test_updater.sh` relied on an old auto-update mechanism that no longer exists.  
This includes the `--updater-mode test` flag and files like `.prover.pid` and `.current_version`.

To prevent confusion, the script is now explicitly marked as **DEPRECATED** at the top:

```bash
# DEPRECATED: This test relies on the old updater logic and does not run in CI.
# It is kept for historical reference only.
```

### Why

Leaving the script unmarked could mislead developers into thinking the auto-update is still tested by this script.
This change keeps the history but clearly signals that it shouldn’t be run.

### Notes

- The functional code has not changed.
- Initially, the possibility of completely removing the script was considered, since it no longer performs its function,
but it was decided to simply add a description.
