### PR TITLE
fix: propagate error from generate_proof_hash instead of panicking

### DIFF
--- a/clients/cli/src/prover/pipeline.rs
+++ b/clients/cli/src/prover/pipeline.rs
@@ -99,8 +99,9 @@ impl ProvingPipeline {
                     )
                     .await?;
 
-                    // Step 3: Generate proof hash
-                    let proof_hash = Self::generate_proof_hash(&proof);
+                    // Step 3: Generate proof hash; propagate serialization errors instead of
+                    // panicking, which would crash the worker process and lose the task.
+                    let proof_hash = Self::generate_proof_hash(&proof)?;
 
                     Ok((proof, proof_hash, input_index))
                 })
@@ -169,10 +170,13 @@ impl ProvingPipeline {
         Ok((all_proofs, final_proof_hash, proof_hashes))
     }
 
-    /// Generate hash for a proof
-    fn generate_proof_hash(proof: &Proof) -> String {
-        let proof_bytes = postcard::to_allocvec(proof).expect("Failed to serialize proof");
-        format!("{:x}", Keccak256::digest(&proof_bytes))
+    /// Generate hash for a proof.
+    ///
+    /// Returns an error instead of panicking if the proof cannot be serialized.
+    /// A panic here would crash the worker process and permanently lose the task.
+    fn generate_proof_hash(proof: &Proof) -> Result<String, ProverError> {
+        let proof_bytes = postcard::to_allocvec(proof)?;
+        Ok(format!("{:x}", Keccak256::digest(&proof_bytes)))
     }
 
     /// Combine multiple proof hashes based on task type


### PR DESCRIPTION
## Problem

In `ProvingPipeline::generate_proof_hash`, proof serialization is done with `postcard::to_allocvec(proof).expect("Failed to serialize proof")`. Any serialization failure (e.g. transient OOM, corrupt proof object) causes an unrecoverable panic that:

1. **Kills the entire CLI process** — the node goes offline.
2. **Loses the task permanently** — there is no retry because the panic unwinds the stack before any error path can re-queue the work.

## Fix

Change `generate_proof_hash` to return `Result<String, ProverError>` and use `?` to propagate the `postcard::Error` (which already has a `From` impl on `ProverError::Serialization`). Update the single call-site in `prove_fib_task` accordingly.

The change is zero-cost on the happy path and lets the worker loop handle the error gracefully (log it, release the semaphore permit, and continue with the next task).