### PR TITLE
fix: update rate-limit timestamp only after successful reportProving request

### DIFF
--- a/clients/cli/src/analytics.rs
+++ b/clients/cli/src/analytics.rs
@@ -176,20 +176,15 @@ pub async fn report_proving_if_needed() {
 
     let now = Instant::now();
 
-    // Check and update last report time with a small critical section
+    // Check (but do NOT update yet) the rate-limit window.
+    // The timestamp is only advanced after a successful request so that a
+    // transient network failure does not suppress retries for a full hour.
     let should_send = {
-        let mut guard = match map.lock() {
+        let guard = match map.lock() {
             Ok(g) => g,
             Err(poisoned) => poisoned.into_inner(),
         };
-
-        match guard.get(wallet_address) {
-            Some(&last) if now.duration_since(last) < Duration::from_secs(3600) => false,
-            _ => {
-                guard.insert(wallet_address.to_string(), now);
-                true
-            }
-        }
+        !matches!(guard.get(wallet_address), Some(&last) if now.duration_since(last) < Duration::from_secs(3600))
     };
 
     if !should_send {
@@ -201,14 +196,34 @@ pub async fn report_proving_if_needed() {
         "data": { "address": wallet_address }
     });
 
-    let response = client
+    let result = client
         .post(REPORT_PROVING_URL)
         .header(reqwest::header::USER_AGENT, CLI_USER_AGENT)
         .json(&body)
         .send()
         .await;
 
-    drop(response);
+    // Only advance the rate-limit timestamp when the request succeeds.
+    // On failure, log the error and leave the timestamp unchanged so the
+    // next invocation can retry rather than silently waiting a full hour.
+    match result {
+        Ok(resp) if resp.status().is_success() => {
+            let mut guard = match map.lock() {
+                Ok(g) => g,
+                Err(poisoned) => poisoned.into_inner(),
+            };
+            guard.insert(wallet_address.to_string(), now);
+        }
+        Ok(resp) => {
+            eprintln!(
+                "[nexus-cli] reportProving returned non-success status: {}",
+                resp.status()
+            );
+        }
+        Err(e) => {
+            eprintln!("[nexus-cli] reportProving request failed: {}", e);
+        }
+    }
 }
 
 /// Track analytics for getting a task from orchestrator (non-blocking)


### PR DESCRIPTION
## Problem

`report_proving_if_needed` contains two bugs that cause nodes to silently lose reward attribution:

### Bug 1 — Timestamp updated before the request

The per-address entry in `LAST_REPORT_BY_ADDRESS` is inserted **before** the HTTP call is made:

```rust
guard.insert(wallet_address.to_string(), now); // ← happens before send()
```

If the network request fails for any reason (timeout, DNS, non-2xx response), the timestamp has already advanced. The rate limiter now blocks all retries for a full hour, so the reward ping is silently lost.

### Bug 2 — `drop(response)` silences all errors

`drop(response)` discards the entire `Result<Response, Error>` value, including network errors and HTTP error statuses. There is no logging, no metric, and no retry signal.

## Fix

- Check (but do **not** update) the rate-limit window before sending.
- After the request, advance the timestamp only when the response indicates success.
- Log non-success outcomes (`eprintln!`) so operators can observe failures.

This preserves the one-report-per-hour intent while ensuring transient failures are retried on the next invocation.