### PR TITLE
fix: add 10-minute timeout to proving subprocess to prevent indefinite hangs

### DIFF
--- a/clients/cli/src/prover/engine.rs
+++ b/clients/cli/src/prover/engine.rs
@@ -14,6 +14,12 @@ use postcard::from_bytes;
 use serde_json;
 use std::env;
 use std::process::Stdio;
+use std::time::Duration;
+
+/// Maximum wall-clock time allowed for a proving subprocess.
+/// A subprocess that exceeds this limit is assumed to have deadlocked or
+/// entered an infinite loop; it is killed and the task is retried.
+const SUBPROCESS_TIMEOUT_SECS: u64 = 600; // 10 minutes
 
 /// Core proving engine for ZK proof generation
 pub struct ProvingEngine;
@@ -63,7 +69,20 @@ impl ProvingEngine {
             .stdout(Stdio::piped())
             .stderr(Stdio::inherit());
 
-        let output = cmd.output().await?;
+        // Apply a hard timeout so a hung subprocess cannot block the worker forever.
+        // If the subprocess deadlocks or enters an infinite loop it will be killed
+        // and the task will be retried on the next fetch cycle.
+        let output = tokio::time::timeout(
+            Duration::from_secs(SUBPROCESS_TIMEOUT_SECS),
+            cmd.output(),
+        )
+        .await
+        .map_err(|_| {
+            ProverError::Subprocess(format!(
+                "Prover subprocess timed out after {} seconds",
+                SUBPROCESS_TIMEOUT_SECS
+            ))
+        })??;
 
         if !output.status.success() {
             if let Some(code) = output.status.code() {


### PR DESCRIPTION
## Problem

`ProvingEngine::prove_and_validate` spawns a child process and awaits `cmd.output()` with no timeout:

```rust
let output = cmd.output().await?; // no deadline
```

If the subprocess deadlocks — infinite loop in the prover, a futex stall under memory pressure, or any other hang — the `await` never resolves. The worker thread is blocked forever, the node stops accepting new tasks, and the only recovery is a manual process kill.

## Fix

Wrap the `cmd.output()` call in `tokio::time::timeout(Duration::from_secs(600))`. On expiry the subprocess is killed (OS sends SIGKILL when the `Child` handle is dropped) and a `ProverError::Subprocess` is returned. The worker loop can then log the error and fetch the next task.

The 600-second constant is introduced as `SUBPROCESS_TIMEOUT_SECS` at the top of the module so it is easy to tune.