### PR TITLE
fix: return error when proof vec is empty instead of submitting empty bytes

### DIFF
--- a/clients/cli/src/workers/submitter.rs
+++ b/clients/cli/src/workers/submitter.rs
@@ -20,6 +20,8 @@ pub enum SubmitError {
     Network(#[from] crate::orchestrator::error::OrchestratorError),
     #[error("Serialization error: {0}")]
     Serialization(#[from] postcard::Error),
+    #[error("No proofs available to submit: proof generation produced an empty result")]
+    NoProofs,
 }
 
 /// Proof submitter with built-in retry and error handling
@@ -80,7 +82,13 @@ impl ProofSubmitter {
             .iter()
             .map(postcard::to_allocvec)
             .collect::<Result<_, _>>()?;
-        let legacy_proof_bytes = proofs_bytes.first().cloned().unwrap_or_default();
+        // Fail explicitly rather than forwarding empty bytes as the proof payload.
+        // An empty submission is silently rejected by the orchestrator, causing the node
+        // to lose the task reward without any visible error.
+        if proofs_bytes.is_empty() {
+            return Err(SubmitError::NoProofs);
+        }
+        let legacy_proof_bytes = proofs_bytes[0].clone();
 
         // Submit through network client with retry logic
         let mut submission = ProofSubmission::new(


### PR DESCRIPTION
## Problem

`ProofSubmitter::submit_proof` derives `legacy_proof_bytes` with:

```rust
let legacy_proof_bytes = proofs_bytes.first().cloned().unwrap_or_default();
```

If `proof_result.proofs` is empty for any reason, `unwrap_or_default()` silently substitutes an empty `Vec<u8>`. That empty bytes slice is then forwarded to the orchestrator as the proof payload. The orchestrator rejects the empty submission, the node loses the task reward, and **nothing in the logs indicates that the proof was empty** — the submission path returns `Ok`.

## Fix

- Add a `NoProofs` variant to `SubmitError`.
- Return `Err(SubmitError::NoProofs)` immediately when `proofs_bytes.is_empty()`, before any network call is attempted.

This surfaces the failure clearly in logs and lets analytics correctly attribute it as a local error rather than a submission error.