### PR TITLE
fix: clamp f64 GFLOP estimate before casting to i32 in node telemetry

### DIFF
--- a/clients/cli/src/orchestrator/client.rs
+++ b/clients/cli/src/orchestrator/client.rs
@@ -447,7 +447,7 @@ impl Orchestrator for OrchestratorClient {
             proof: proof_to_send,
             proofs: proofs_to_send,
             node_telemetry: Some(crate::nexus_orchestrator::NodeTelemetry {
-                flops_per_sec: Some(flops as i32),
+                flops_per_sec: Some(flops.clamp(i32::MIN as f64, i32::MAX as f64) as i32),
                 memory_used: Some(program_memory),
                 memory_capacity: Some(total_memory),
                 // Country code for network routing optimization (privacy-preserving)


### PR DESCRIPTION
## Problem

`OrchestratorClient::submit_proof` includes a node telemetry payload:

```rust
flops_per_sec: Some(flops as i32),
```

where `flops` is the `f64` returned by `estimate_peak_gflops`. For machines with many cores (roughly 16+ depending on the GFLOP model), the estimate exceeds `i32::MAX` (≈2.1 billion). In Rust 1.45+ the `as i32` cast saturates to `i32::MAX`, but for values that overflow further it can saturate to `i32::MIN` (a large negative number), corrupting the telemetry field and making the node appear to have near-zero or negative compute capacity.

## Fix

Clamp the value to `[i32::MIN, i32::MAX]` before the cast:

```rust
flops_per_sec: Some(flops.clamp(i32::MIN as f64, i32::MAX as f64) as i32),
```

This is a one-character change that makes the conversion well-defined and correct for all inputs.