### PR TITLE
fix: look up real user_id instead of hardcoding anonymous for --node-id path

### DIFF
--- a/clients/cli/src/config.rs
+++ b/clients/cli/src/config.rs
@@ -104,9 +104,17 @@ impl Config {
             // Get the wallet address for analytics
             let wallet_address = orchestrator.get_node(&node_id.to_string()).await?;
 
-            // Create a minimal config with the provided node_id
+            // Resolve the user_id for this wallet so that analytics and reward
+            // tracking use the real identity instead of a placeholder string.
+            // A lookup failure is non-fatal: fall back to an empty string so the
+            // node can still prove and submit tasks.
+            let user_id = orchestrator
+                .get_user(&wallet_address)
+                .await
+                .unwrap_or_else(|_| String::new());
+
             let config = Config {
-                user_id: "anonymous".to_string(), // Use anonymous for --node-id shortcut
+                user_id,
                 wallet_address,
                 node_id: node_id.to_string(),
                 environment: "".to_string(),


### PR DESCRIPTION
## Problem

When a user starts the node with `--node-id <id>`, `Config::resolve` creates a config with:

```rust
user_id: "anonymous".to_string(), // Use anonymous for --node-id shortcut
```

Every analytics event, reward report (via `set_wallet_address_for_reporting` → `report_proving_if_needed`), and orchestrator call for the entire session then identifies the user as **`"anonymous"`**. This:

1. **Corrupts per-user telemetry** — all events from `--node-id` nodes are bucketed under a single fake identity.
2. **May break reward tracking** — if the orchestrator or cloud function validates user_id against registered accounts, an `"anonymous"` value could cause silent rejections.

Any user who runs `nexus-cli start --node-id <id>` (rather than the full register + start flow) is affected.

## Fix

After resolving `wallet_address` via `orchestrator.get_node()`, make a second call to `orchestrator.get_user(&wallet_address)` to obtain the real `user_id`. A lookup failure is treated as non-fatal (falls back to an empty string) so node startup is never blocked.