### PR TITLE
feat: rename compute CLI nexus-cli → nexus-compute-cli (with alias)

### DIFF
--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -37,11 +37,11 @@ jobs:
           BASE_URL="https://github.com/nexus-xyz/nexus-cli/releases/download/${VERSION}"
 
           # Define the download URLs for each platform
-          LINUX_X86_64_URL="${BASE_URL}/nexus-network-linux-x86_64"
-          LINUX_ARM64_URL="${BASE_URL}/nexus-network-linux-arm64"
-          MACOS_X86_64_URL="${BASE_URL}/nexus-network-macos-x86_64"
-          MACOS_ARM64_URL="${BASE_URL}/nexus-network-macos-arm64"
-          WINDOWS_X86_64_URL="${BASE_URL}/nexus-network-windows-x86_64.exe"
+          LINUX_X86_64_URL="${BASE_URL}/nexus-compute-cli-linux-x86_64"
+          LINUX_ARM64_URL="${BASE_URL}/nexus-compute-cli-linux-arm64"
+          MACOS_X86_64_URL="${BASE_URL}/nexus-compute-cli-macos-x86_64"
+          MACOS_ARM64_URL="${BASE_URL}/nexus-compute-cli-macos-arm64"
+          WINDOWS_X86_64_URL="${BASE_URL}/nexus-compute-cli-windows-x86_64.exe"
 
           # Replace placeholders in the template
           sed -e "s|__LINUX_X86_64_URL__|${LINUX_X86_64_URL}|g" \

--- a/.github/workflows/firebase-hosting-release.yml
+++ b/.github/workflows/firebase-hosting-release.yml
@@ -43,11 +43,11 @@ jobs:
           BASE_URL="https://github.com/nexus-xyz/nexus-cli/releases/download/${VERSION}"
 
           # Define the download URLs for each platform
-          LINUX_X86_64_URL="${BASE_URL}/nexus-network-linux-x86_64"
-          LINUX_ARM64_URL="${BASE_URL}/nexus-network-linux-arm64"
-          MACOS_X86_64_URL="${BASE_URL}/nexus-network-macos-x86_64"
-          MACOS_ARM64_URL="${BASE_URL}/nexus-network-macos-arm64"
-          WINDOWS_X86_64_URL="${BASE_URL}/nexus-network-windows-x86_64.exe"
+          LINUX_X86_64_URL="${BASE_URL}/nexus-compute-cli-linux-x86_64"
+          LINUX_ARM64_URL="${BASE_URL}/nexus-compute-cli-linux-arm64"
+          MACOS_X86_64_URL="${BASE_URL}/nexus-compute-cli-macos-x86_64"
+          MACOS_ARM64_URL="${BASE_URL}/nexus-compute-cli-macos-arm64"
+          WINDOWS_X86_64_URL="${BASE_URL}/nexus-compute-cli-windows-x86_64.exe"
 
           # Replace placeholders in the template
           sed -e "s|__LINUX_X86_64_URL__|${LINUX_X86_64_URL}|g" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,14 +90,14 @@ jobs:
       # Rename the binary to indicate the target OS
       - name: Rename binary
         working-directory: clients/cli/target/x86_64-unknown-linux-gnu/release/
-        run: cp nexus-network nexus-network-linux-x86_64
+        run: cp nexus-network nexus-compute-cli-linux-x86_64
 
       # Upload the binary as an artifact
       - name: Upload artifact
         uses: actions/upload-artifact@v6
         with:
-          name: nexus-network-linux-x86_64 # Name of the artifact
-          path: clients/cli/target/x86_64-unknown-linux-gnu/release/nexus-network-linux-x86_64 # Path to file to upload
+          name: nexus-compute-cli-linux-x86_64 # Name of the artifact
+          path: clients/cli/target/x86_64-unknown-linux-gnu/release/nexus-compute-cli-linux-x86_64 # Path to file to upload
 
 
   build-linux-arm64:
@@ -157,14 +157,14 @@ jobs:
       # Rename the binary to indicate the target OS
       - name: Rename binary
         working-directory: clients/cli/target/aarch64-unknown-linux-gnu/release/
-        run: cp nexus-network nexus-network-linux-arm64
+        run: cp nexus-network nexus-compute-cli-linux-arm64
 
       # Upload the binary as an artifact
       - name: Upload artifact
         uses: actions/upload-artifact@v6
         with:
-          name: nexus-network-linux-arm64 # Name of the artifact
-          path: clients/cli/target/aarch64-unknown-linux-gnu/release/nexus-network-linux-arm64 # Path to file to upload
+          name: nexus-compute-cli-linux-arm64 # Name of the artifact
+          path: clients/cli/target/aarch64-unknown-linux-gnu/release/nexus-compute-cli-linux-arm64 # Path to file to upload
 
   build-macos-x86_64:
     name: Build macOS (x86_64)
@@ -220,15 +220,15 @@ jobs:
       # Rename the binary to indicate the target OS
       - name: Rename binary
         working-directory: clients/cli/target/x86_64-apple-darwin/release/
-        run: cp nexus-network nexus-network-macos-x86_64
+        run: cp nexus-network nexus-compute-cli-macos-x86_64
 
 
       # Upload the binary as an artifact
       - name: Upload artifact
         uses: actions/upload-artifact@v6
         with:
-          name: nexus-network-macos-x86_64 # Name of the artifact
-          path: clients/cli/target/x86_64-apple-darwin/release/nexus-network-macos-x86_64 # Path to file to upload
+          name: nexus-compute-cli-macos-x86_64 # Name of the artifact
+          path: clients/cli/target/x86_64-apple-darwin/release/nexus-compute-cli-macos-x86_64 # Path to file to upload
 
 
   build-macos-arm64:
@@ -277,14 +277,14 @@ jobs:
       # Rename the binary to indicate the target OS and platform
       - name: Rename binary
         working-directory: clients/cli/target/aarch64-apple-darwin/release/
-        run: cp nexus-network nexus-network-macos-arm64
+        run: cp nexus-network nexus-compute-cli-macos-arm64
 
       # Upload the binary as an artifact
       - name: Upload artifact
         uses: actions/upload-artifact@v6
         with:
-          name: nexus-network-macos-arm64 # Name of the artifact
-          path: clients/cli/target/aarch64-apple-darwin/release/nexus-network-macos-arm64 # Path to file to upload
+          name: nexus-compute-cli-macos-arm64 # Name of the artifact
+          path: clients/cli/target/aarch64-apple-darwin/release/nexus-compute-cli-macos-arm64 # Path to file to upload
 
 
   build-windows-x86_64:
@@ -330,14 +330,14 @@ jobs:
       # Rename the binary to indicate the target OS and platform
       - name: Rename binary
         working-directory: clients/cli/target/x86_64-pc-windows-msvc/release/
-        run: cp nexus-network.exe nexus-network-windows-x86_64.exe
+        run: cp nexus-network.exe nexus-compute-cli-windows-x86_64.exe
 
       # Upload the binary as an artifact
       - name: Upload artifact
         uses: actions/upload-artifact@v6
         with:
-          name: nexus-network-windows-x86_64.exe # Name of the artifact
-          path: clients/cli/target/x86_64-pc-windows-msvc/release/nexus-network-windows-x86_64.exe # Path to file to upload
+          name: nexus-compute-cli-windows-x86_64.exe # Name of the artifact
+          path: clients/cli/target/x86_64-pc-windows-msvc/release/nexus-compute-cli-windows-x86_64.exe # Path to file to upload
 
 
   release:
@@ -372,16 +372,16 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: |
-            artifacts/nexus-network-macos-arm64
-            artifacts/nexus-network-macos-arm64.sha256
-            artifacts/nexus-network-macos-x86_64
-            artifacts/nexus-network-macos-x86_64.sha256
-            artifacts/nexus-network-linux-arm64
-            artifacts/nexus-network-linux-arm64.sha256
-            artifacts/nexus-network-linux-x86_64
-            artifacts/nexus-network-linux-x86_64.sha256
-            artifacts/nexus-network-windows-x86_64.exe
-            artifacts/nexus-network-windows-x86_64.exe.sha256
+            artifacts/nexus-compute-cli-macos-arm64
+            artifacts/nexus-compute-cli-macos-arm64.sha256
+            artifacts/nexus-compute-cli-macos-x86_64
+            artifacts/nexus-compute-cli-macos-x86_64.sha256
+            artifacts/nexus-compute-cli-linux-arm64
+            artifacts/nexus-compute-cli-linux-arm64.sha256
+            artifacts/nexus-compute-cli-linux-x86_64
+            artifacts/nexus-compute-cli-linux-x86_64.sha256
+            artifacts/nexus-compute-cli-windows-x86_64.exe
+            artifacts/nexus-compute-cli-windows-x86_64.exe.sha256
           draft: false
           prerelease: false
           generate_release_notes: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,4 @@ RUN apk update && \
     chmod +x install.sh && \
     NONINTERACTIVE=1 ./install.sh
 
-ENTRYPOINT ["/root/.nexus/bin/nexus-cli"]
+ENTRYPOINT ["/root/.nexus/bin/nexus-compute-cli"]

--- a/README.md
+++ b/README.md
@@ -47,6 +47,11 @@ chmod +x install.sh
 NONINTERACTIVE=1 ./install.sh
 ```
 
+> **Note on the command name:** The CLI command is now `nexus-compute-cli`. The
+> previous name, `nexus-cli`, continues to work as an alias during the transition
+> window, so existing scripts won't break — but new setups should use
+> `nexus-compute-cli`.
+
 ### Proving
 
 Proving with the CLI is documented [here](https://docs.nexus.xyz/network/proving-on-the-layer-1/contribute-via-cli).
@@ -54,21 +59,21 @@ Proving with the CLI is documented [here](https://docs.nexus.xyz/network/proving
 To start with an existing node ID, run:
 
 ```bash
-nexus-cli start --node-id <your-node-id>
+nexus-compute-cli start --node-id <your-node-id>
 ```
 
 Alternatively, you can register your wallet address and create a node ID with the CLI, or at [app.nexus.xyz](https://app.nexus.xyz).
 
 ```bash
-nexus-cli register-user --wallet-address <your-wallet-address>
-nexus-cli register-node --node-id <your-cli-node-id>
-nexus-cli start
+nexus-compute-cli register-user --wallet-address <your-wallet-address>
+nexus-compute-cli register-node --node-id <your-cli-node-id>
+nexus-compute-cli start
 ```
 
 To run the CLI noninteractively, you can also opt to start it in headless mode.
 
 ```bash
-nexus-cli start --headless
+nexus-compute-cli start --headless
 ```
 
 #### Quick Reference
@@ -76,13 +81,13 @@ nexus-cli start --headless
 The `register-user` and `register-node` commands will save your credentials to `~/.nexus/config.json`. To clear credentials, run:
 
 ```bash
-nexus-cli logout
+nexus-compute-cli logout
 ```
 
 For troubleshooting or to see available command-line options, run:
 
 ```bash
-nexus-cli --help
+nexus-compute-cli --help
 ```
 
 ### Adaptive Task Difficulty
@@ -111,24 +116,24 @@ The Nexus CLI features an **adaptive difficulty system** that automatically adju
 
 ```bash
 # Lower difficulty for resource-constrained systems
-nexus-cli start --max-difficulty small
-nexus-cli start --max-difficulty small_medium
+nexus-compute-cli start --max-difficulty small
+nexus-compute-cli start --max-difficulty small_medium
 
 # Higher difficulty for powerful hardware
-nexus-cli start --max-difficulty medium
-nexus-cli start --max-difficulty large
-nexus-cli start --max-difficulty extra_large
-nexus-cli start --max-difficulty extra_large_2
-nexus-cli start --max-difficulty extra_large_3
-nexus-cli start --max-difficulty extra_large_4
+nexus-compute-cli start --max-difficulty medium
+nexus-compute-cli start --max-difficulty large
+nexus-compute-cli start --max-difficulty extra_large
+nexus-compute-cli start --max-difficulty extra_large_2
+nexus-compute-cli start --max-difficulty extra_large_3
+nexus-compute-cli start --max-difficulty extra_large_4
 
 # Equivalent to extra_large_4 if no extra_large_5 tasks available
-nexus-cli start --max-difficulty extra_large_5
+nexus-compute-cli start --max-difficulty extra_large_5
 
 # Case-insensitive (all equivalent)
-nexus-cli start --max-difficulty MEDIUM
-nexus-cli start --max-difficulty medium
-nexus-cli start --max-difficulty Medium
+nexus-compute-cli start --max-difficulty MEDIUM
+nexus-compute-cli start --max-difficulty medium
+nexus-compute-cli start --max-difficulty Medium
 ```
 
 #### Difficulty Guidelines
@@ -140,7 +145,7 @@ nexus-cli start --max-difficulty Medium
 | `medium` and `large` | Standard desktop/laptop |
 | `extra_large` and above | High-performance systems, more points |
 
-> **Tip**: Use `nexus-cli start --help` to see the full auto-promotion details in the CLI help text.
+> **Tip**: Use `nexus-compute-cli start --help` to see the full auto-promotion details in the CLI help text.
 
 #### Troubleshooting Difficulty Issues
 
@@ -149,7 +154,7 @@ nexus-cli start --max-difficulty Medium
 Try a lower difficulty.
 
 ```bash
-nexus-cli start --max-difficulty small_medium
+nexus-compute-cli start --max-difficulty small_medium
 ```
 
 **Want more challenging tasks:**
@@ -157,7 +162,7 @@ nexus-cli start --max-difficulty small_medium
 Request a harder difficulty. It will still take time to build up reputation to get the requested difficulty.
 
 ```bash
-nexus-cli start --max-difficulty extra_large_2
+nexus-compute-cli start --max-difficulty extra_large_2
 ```
 
 **Unsure about system capabilities:**

--- a/clients/cli/scripts/README.md
+++ b/clients/cli/scripts/README.md
@@ -84,7 +84,7 @@ All errors are displayed with red text and include helpful error messages.
 
 ## Peak Memory Monitor Script
 
-The `peak_memory.sh` script monitors the peak memory usage of the nexus-cli during operation.
+The `peak_memory.sh` script monitors the peak memory usage of the nexus-compute-cli during operation.
 
 ### Usage
 
@@ -111,7 +111,7 @@ The `peak_memory.sh` script monitors the peak memory usage of the nexus-cli duri
 
 ### What it does
 
-1. Starts `nexus-cli start --headless` in the background
+1. Starts `nexus-compute-cli start --headless` in the background
 2. Monitors memory usage every second for the specified duration
 3. Tracks peak memory usage throughout the run
 4. Displays real-time current and peak memory usage
@@ -121,7 +121,7 @@ The `peak_memory.sh` script monitors the peak memory usage of the nexus-cli duri
 
 ```bash
 ❯ ./scripts/peak_memory.sh 20
-Starting nexus-cli and monitoring memory for 20 seconds...
+Starting nexus-compute-cli and monitoring memory for 20 seconds...
 [1/20s] Current: 4 MB, Peak: 4 MB
 [INFO!!!] ✅ Found Node ID from config file      Node ID: 19444429
 Refresh [2025-07-31 08:09:24] Task Fetcher: [Task step 1 of 3] Fetching task...
@@ -145,5 +145,5 @@ Total Runtime: 21 seconds
 ```
 ### Requirements
 
-- `nexus-cli` must be built and available in PATH or current directory
+- `nexus-compute-cli` must be built and available in PATH or current directory
 - Valid nexus configuration (Node ID) for proper operation

--- a/clients/cli/scripts/peak_memory.sh
+++ b/clients/cli/scripts/peak_memory.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 
-# This script measures the peak memory usage of the nexus-cli binary.
+# This script measures the peak memory usage of the nexus-compute-cli binary.
 # It starts the binary in headless mode and monitors the memory usage for specified seconds.
 # Usage: ./peak_memory.sh [SECONDS] (default: 60)
 
 DURATION=${1:-60}
 
-echo "Starting nexus-cli and monitoring memory for ${DURATION} seconds..."
+echo "Starting nexus-compute-cli and monitoring memory for ${DURATION} seconds..."
 
 # Start the process in background and capture its PID
-nexus-cli start --headless &
+nexus-compute-cli start --headless &
 PID=$!
 
 # Record start time

--- a/clients/cli/src/config.rs
+++ b/clients/cli/src/config.rs
@@ -119,7 +119,7 @@ impl Config {
         if !config_path.exists() {
             print_info(
                 "Welcome to Nexus CLI!",
-                "Please register your wallet address to get started: nexus-cli register-user --wallet-address <your-wallet-address>",
+                "Please register your wallet address to get started: nexus-compute-cli register-user --wallet-address <your-wallet-address>",
             );
             return Err("Configuration file not found. Please register first.".into());
         }
@@ -140,7 +140,7 @@ impl Config {
                 // The config is present but incomplete or invalid
                 print_error(
                     "Your configuration is incomplete or invalid.",
-                    Some("Please register your node. Start with: nexus-cli register-node"),
+                    Some("Please register your node. Start with: nexus-compute-cli register-node"),
                 );
                 return Err(e);
             }
@@ -165,10 +165,10 @@ impl Config {
         if self.node_id.is_empty() {
             print_error(
                 "User registered, but no node found",
-                Some("Please register a node to continue: nexus-cli register-node"),
+                Some("Please register a node to continue: nexus-compute-cli register-node"),
             );
             return Err(
-                "Node registration required. Please run 'nexus-cli register-node' first.".into(),
+                "Node registration required. Please run 'nexus-compute-cli register-node' first.".into(),
             );
         }
 
@@ -177,10 +177,10 @@ impl Config {
             Err(_) => {
                 print_error(
                     "Invalid node ID in config file",
-                    Some("Please register a new node: nexus-cli register-node"),
+                    Some("Please register a new node: nexus-compute-cli register-node"),
                 );
                 Err(
-                    "Invalid node ID in config. Please run 'nexus-cli register-node' to fix this."
+                    "Invalid node ID in config. Please run 'nexus-compute-cli register-node' to fix this."
                         .into(),
                 )
             }

--- a/clients/cli/src/config.rs
+++ b/clients/cli/src/config.rs
@@ -168,7 +168,8 @@ impl Config {
                 Some("Please register a node to continue: nexus-compute-cli register-node"),
             );
             return Err(
-                "Node registration required. Please run 'nexus-compute-cli register-node' first.".into(),
+                "Node registration required. Please run 'nexus-compute-cli register-node' first."
+                    .into(),
             );
         }
 

--- a/clients/cli/src/register.rs
+++ b/clients/cli/src/register.rs
@@ -50,7 +50,7 @@ pub async fn register_user(
                 // Guide user to next step
                 print_success(
                     "User registration complete!",
-                    "Next step - register a node: nexus-cli register-node",
+                    "Next step - register a node: nexus-compute-cli register-node",
                 );
                 return Ok(());
             }
@@ -77,7 +77,7 @@ pub async fn register_user(
         // Guide user to next step
         print_success(
             "User registration complete!",
-            "Next step - register a node: nexus-cli register-node",
+            "Next step - register a node: nexus-compute-cli register-node",
         );
 
         return Ok(());
@@ -118,7 +118,7 @@ pub async fn register_user(
     // Guide user to next step
     print_success(
         "User registration complete!",
-        "Next step - register a node: nexus-cli register-node",
+        "Next step - register a node: nexus-compute-cli register-node",
     );
 
     Ok(())
@@ -163,7 +163,7 @@ pub async fn register_node(
         print_success(
             "Node registration complete!",
             &format!(
-                "Successfully registered node with ID: {}. Next step - start proving: nexus-cli start",
+                "Successfully registered node with ID: {}. Next step - start proving: nexus-compute-cli start",
                 node_id
             ),
         );
@@ -187,7 +187,7 @@ pub async fn register_node(
                 print_success(
                     "Node registration complete!",
                     &format!(
-                        "Successfully registered node with ID: {}. Next step - start proving: nexus-cli start",
+                        "Successfully registered node with ID: {}. Next step - start proving: nexus-compute-cli start",
                         node_id
                     ),
                 );

--- a/public/install.sh.template
+++ b/public/install.sh.template
@@ -148,7 +148,7 @@ fi
 echo "Downloading latest release for ${GREEN}$PLATFORM-$ARCH${NC}..."
 echo "Downloading from: ${GREEN}$DOWNLOAD_URL${NC}"
 
-if ! curl -L -o "$BIN_DIR/nexus-network" "$DOWNLOAD_URL"; then
+if ! curl -L -o "$BIN_DIR/nexus-compute-cli" "$DOWNLOAD_URL"; then
     echo "${RED}Failed to download binary from $DOWNLOAD_URL${NC}"
     echo "Please try again or build from source:"
     echo "  git clone https://github.com/nexus-xyz/nexus-cli.git"
@@ -157,9 +157,12 @@ if ! curl -L -o "$BIN_DIR/nexus-network" "$DOWNLOAD_URL"; then
     exit 1
 fi
 
-chmod +x "$BIN_DIR/nexus-network"
-ln -s "$BIN_DIR/nexus-network" "$BIN_DIR/nexus-cli"
-chmod +x "$BIN_DIR/nexus-cli"
+chmod +x "$BIN_DIR/nexus-compute-cli"
+
+# The canonical command is now `nexus-compute-cli`. Keep `nexus-cli` as a
+# backward-compatible alias through the transition window so existing prover
+# scripts and the self-updater keep working.
+ln -sf "$BIN_DIR/nexus-compute-cli" "$BIN_DIR/nexus-cli"
 
 # -----------------------------------------------------------------------------
 # 6) Add $BIN_DIR to PATH if not already present
@@ -193,5 +196,5 @@ echo "  source $PROFILE_FILE"
 echo ""
 echo "${ORANGE}To get your node ID, visit: https://app.nexus.xyz/nodes${NC}"
 echo ""
-echo "Register your user to begin linked proving with the Nexus CLI by: nexus-cli register-user --wallet-address <WALLET_ADDRESS>"
+echo "Register your user to begin linked proving with the Nexus CLI by: nexus-compute-cli register-user --wallet-address <WALLET_ADDRESS>"
 echo "Or follow the guide at https://docs.nexus.xyz/network/proving-on-the-layer-1/contribute-via-cli"


### PR DESCRIPTION
Renames the prover/compute CLI command `nexus-cli` → **`nexus-compute-cli`**, keeping `nexus-cli` as a backward-compatible **alias** through the transition window. This lets the bare-brand `cli.nexus.xyz` entrypoint later default to the exchange `nexus` CLI without stranding the prover community.

## Changes (scope: command/binary + release assets + install script + docs)

**Command / binary**
- `public/install.sh.template` — installs the binary as `nexus-compute-cli` (canonical) and symlinks `nexus-cli` → `nexus-compute-cli`. Switched to `ln -sf` so re-running the installer on an existing prover re-points cleanly instead of failing.
- `Dockerfile` — `ENTRYPOINT` → `nexus-compute-cli` (alias still resolves).

**GitHub release asset names**
- `.github/workflows/release.yml` — release assets + `.sha256` renamed `nexus-network-*` → `nexus-compute-cli-*` (the `cp` source, the cargo-built `nexus-network`, is unchanged).
- `.github/workflows/firebase-hosting-release.yml` & `firebase-hosting-pull-request.yml` — install-script download URLs updated to match, kept in lockstep with the asset names.

**User-facing text & docs**
- `clients/cli/src/config.rs`, `clients/cli/src/register.rs` — guidance messages now reference `nexus-compute-cli`.
- `README.md` (command examples + an explanatory note about the alias), `clients/cli/scripts/README.md`, `clients/cli/scripts/peak_memory.sh`.

## Why this won't hard-break existing provers
The shipped self-updater (`version/checker.rs`) only reads the **release tag** from the GitHub API — it never references asset names or downloads binaries itself. Old releases keep their (immutable) `nexus-network-*` asset names; only new releases use the new names, and the regenerated `install.sh` always points at the correct ones. The `nexus-cli` command keeps working via the alias symlink.

## Intentionally deferred (coordinate with the repo rename)
Left untouched because they point at live, not-yet-renamed resources and would break if flipped now:
- `github.com/nexus-xyz/nexus-cli` repo URLs (version checker GitHub API call, raw config fallback, badges, issue links)
- Firebase project ID `nexus-cli`, cloud-function URL `us-central1-nexus-cli`, Docker Hub image `nexusxyz/nexus-cli`, backend analytics User-Agents, `docker-compose` service name, and the internal cargo crate/bin `nexus-network`

## Testing
- Shell syntax validated (`sh -n`) for the install template and `peak_memory.sh`.
- Rust edits are string-literal-only; no tests referenced the old command/symlink name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
