### PR TITLE
chore: release 0.10.19 — first release with renamed nexus-compute-cli assets (ENG-4942)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,14 @@ jobs:
     name: Build and Test
     runs-on: ubuntu-latest
 
+    # clients/cli/.cargo/config.toml sets `target-cpu=native`, which on GitHub's
+    # shared runner fleet emits instructions the runner faults on -> SIGILL at
+    # clippy/build time. release.yml already overrides this with `target-cpu=generic`
+    # for the shipped binaries; mirror that here (RUSTFLAGS env wins over config.toml)
+    # so CI is stable and checks the same codegen baseline that actually ships.
+    env:
+      RUSTFLAGS: "-C target-cpu=generic"
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/clients/cli/Cargo.lock
+++ b/clients/cli/Cargo.lock
@@ -1677,7 +1677,7 @@ dependencies = [
 
 [[package]]
 name = "nexus-network"
-version = "0.10.18"
+version = "0.10.19"
 dependencies = [
  "assert_cmd",
  "async-trait",

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nexus-network"
-version = "0.10.18"
+version = "0.10.19"
 edition = "2024"
 rust-version = "1.85"
 build = "build.rs"


### PR DESCRIPTION
Bumps `clients/cli/Cargo.toml` `0.10.18` → `0.10.19` so we can cut the first release **after** the `nexus-cli` → `nexus-compute-cli` rename (#2101, ENG-3920).

## Why

The rename is on `main` but the latest release is still `v0.10.18` (Feb 2026, pre-rename). Because `cli.nexus.xyz/compute` proxies the Firebase-hosted `install.sh`, which points at the latest release assets, the `/compute` path still hands prover users the old `nexus-network-*` binaries. This blocks the `cli.nexus.xyz` cutover (ENG-3938).

## What happens on tag

Merging this + pushing a **`v0.10.19`** tag fires the existing workflows (no config changes needed — asset renaming, install template, and Firebase URLs were all wired in #2101):

- `release.yml` → publishes the release with `nexus-compute-cli-*` asset names (Docker `nexusxyz/nexus-cli:latest` as usual).
- `firebase-hosting-release.yml` → regenerates `install.sh` pointing at the renamed assets.

`nexus-cli` remains as an alias (symlink in the install template), so existing provers are not broken.

## Scope

Version bump only (`Cargo.toml` + `Cargo.lock`). `main` is just 5 commits ahead of `v0.10.18`, and those commits are the rename — no unrelated backlog ships here.

⚠️ Publishing is outward-facing (prover community + Docker `latest`). Coordinate the tag push/timing with the compute/prover release owner.

Closes ENG-4942.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Dependencies

- **Prerequisite (merged):** #2101 — the nexus-cli → nexus-compute-cli rename that wired the renamed asset names + install.sh template. No open PR dependency.
- **Gating the full effect (not a PR):** the Firebase service-account secret `FIREBASE_SERVICE_ACCOUNT_NEXUS_CLI` is currently malformed — tracked in **ENG-4954**. `Build and Test` is green after the target-cpu=native fix, but the `Deploy Preview` / `build_and_preview` checks fail on it, and the same secret is used by the tag-triggered `firebase-hosting-release.yml`. So after merge + `v0.10.19` tag, the GitHub release assets publish fine, but the hosted `install.sh` will not republish (and cli.nexus.xyz/compute keeps serving the stale script) until ENG-4954 is fixed by a repo admin.
- **Downstream:** unblocks ENG-4942 → part of the cli.nexus.xyz cutover ENG-3938 (also gated on DNS reconciliation nexus#2270).